### PR TITLE
Add Modbus data acquisition tests and trigger checks

### DIFF
--- a/DataAcquisition.Core.Tests/DataAcquisition.Core.Tests.csproj
+++ b/DataAcquisition.Core.Tests/DataAcquisition.Core.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.7.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataAcquisition.Core\DataAcquisition.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DataAcquisition.Core.Tests/DataAcquisitions/ModbusDataAcquisitionTests.cs
+++ b/DataAcquisition.Core.Tests/DataAcquisitions/ModbusDataAcquisitionTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HslCommunication.Core.Device;
+using Xunit;
+using DataAcquisition.Core.DataAcquisitions;
+using DataAcquisition.Core.DeviceConfigs;
+using DataAcquisition.Core.QueueManagers;
+using DataAcquisition.Core.Messages;
+using DataAcquisition.Core.Communication;
+using HslCommunication.ModBus;
+
+namespace DataAcquisition.Core.Tests.DataAcquisitions;
+
+public class ModbusDataAcquisitionTests : IDisposable
+{
+    private readonly ModbusTcpServer _server;
+    private readonly int _port = 1502;
+
+    public ModbusDataAcquisitionTests()
+    {
+        _server = new ModbusTcpServer();
+        _server.ServerStart(_port);
+    }
+
+    [Fact]
+    public async Task AlwaysTriggerCollectsData()
+    {
+        _server.Write("100", (short)123);
+        var config = CreateConfig(TriggerMode.Always);
+        var deviceConfigService = new StubDeviceConfigService(config);
+        var driverFactory = new StubPlcDriverFactory();
+        var queueFactory = new StubQueueManagerFactory();
+        var messageService = new StubMessageService();
+        var service = new DataAcquisitionService(deviceConfigService, driverFactory, queueFactory, messageService);
+
+        await service.StartCollectionTasks();
+        await Task.Delay(200);
+
+        var queue = queueFactory.Manager;
+        Assert.NotNull(queue);
+        Assert.NotEmpty(queue.Messages);
+        Assert.Equal(123, queue.Messages[0].Values["value"]);
+
+        await service.StopCollectionTasks();
+    }
+
+    [Fact]
+    public async Task ValueIncreaseTriggerCollectsOnRise()
+    {
+        _server.Write("100", (short)1);
+        var config = CreateConfig(TriggerMode.ValueIncrease);
+        var deviceConfigService = new StubDeviceConfigService(config);
+        var driverFactory = new StubPlcDriverFactory();
+        var queueFactory = new StubQueueManagerFactory();
+        var messageService = new StubMessageService();
+        var service = new DataAcquisitionService(deviceConfigService, driverFactory, queueFactory, messageService);
+
+        await service.StartCollectionTasks();
+        await Task.Delay(200);
+        var queue = queueFactory.Manager;
+        queue.Messages.Clear();
+
+        _server.Write("100", (short)2);
+        await Task.Delay(200);
+
+        Assert.Single(queue.Messages);
+        Assert.Equal(2, queue.Messages[0].Values["value"]);
+
+        await service.StopCollectionTasks();
+    }
+
+    [Fact]
+    public async Task ValueDecreaseTriggerCollectsOnDrop()
+    {
+        _server.Write("100", (short)2);
+        var config = CreateConfig(TriggerMode.ValueDecrease);
+        var deviceConfigService = new StubDeviceConfigService(config);
+        var driverFactory = new StubPlcDriverFactory();
+        var queueFactory = new StubQueueManagerFactory();
+        var messageService = new StubMessageService();
+        var service = new DataAcquisitionService(deviceConfigService, driverFactory, queueFactory, messageService);
+
+        await service.StartCollectionTasks();
+        await Task.Delay(200);
+        var queue = queueFactory.Manager;
+        queue.Messages.Clear();
+
+        _server.Write("100", (short)1);
+        await Task.Delay(200);
+
+        Assert.Single(queue.Messages);
+        Assert.Equal(1, queue.Messages[0].Values["value"]);
+
+        await service.StopCollectionTasks();
+    }
+
+    [Fact]
+    public async Task RisingEdgeTriggerCollectsOnTransition()
+    {
+        _server.Write("100", (short)0);
+        var config = CreateConfig(TriggerMode.RisingEdge);
+        var deviceConfigService = new StubDeviceConfigService(config);
+        var driverFactory = new StubPlcDriverFactory();
+        var queueFactory = new StubQueueManagerFactory();
+        var messageService = new StubMessageService();
+        var service = new DataAcquisitionService(deviceConfigService, driverFactory, queueFactory, messageService);
+
+        await service.StartCollectionTasks();
+        await Task.Delay(200);
+        var queue = queueFactory.Manager;
+        queue.Messages.Clear();
+
+        _server.Write("100", (short)1);
+        await Task.Delay(200);
+
+        Assert.Single(queue.Messages);
+        Assert.Equal(1, queue.Messages[0].Values["value"]);
+
+        await service.StopCollectionTasks();
+    }
+
+    [Fact]
+    public async Task FallingEdgeTriggerCollectsOnTransition()
+    {
+        _server.Write("100", (short)1);
+        var config = CreateConfig(TriggerMode.FallingEdge);
+        var deviceConfigService = new StubDeviceConfigService(config);
+        var driverFactory = new StubPlcDriverFactory();
+        var queueFactory = new StubQueueManagerFactory();
+        var messageService = new StubMessageService();
+        var service = new DataAcquisitionService(deviceConfigService, driverFactory, queueFactory, messageService);
+
+        await service.StartCollectionTasks();
+        await Task.Delay(200);
+        var queue = queueFactory.Manager;
+        queue.Messages.Clear();
+
+        _server.Write("100", (short)0);
+        await Task.Delay(200);
+
+        Assert.Single(queue.Messages);
+        Assert.Equal(0, queue.Messages[0].Values["value"]);
+
+        await service.StopCollectionTasks();
+    }
+
+    private DeviceConfig CreateConfig(TriggerMode mode)
+    {
+        return new DeviceConfig
+        {
+            IsEnabled = true,
+            Code = "P1",
+            Host = "127.0.0.1",
+            Port = (ushort)_port,
+            DriverType = "ModbusTcpNet",
+            HeartbeatMonitorRegister = "1",
+            HeartbeatPollingInterval = 50,
+            Modules = new List<Module>
+            {
+                new Module
+                {
+                    ChamberCode = "C1",
+                    Trigger = new Trigger { Mode = mode },
+                    BatchReadRegister = "100",
+                    BatchReadLength = 1,
+                    TableName = "tbl",
+                    DataPoints = new List<DataPoint>
+                    {
+                        new DataPoint{ ColumnName = "value", Index = 0, StringByteLength = 0, DataType = "short", Encoding = ""},
+                    }
+                }
+            }
+        };
+    }
+
+    public void Dispose()
+    {
+        _server.ServerClose();
+    }
+}
+
+internal class StubDeviceConfigService : IDeviceConfigService
+{
+    private readonly DeviceConfig _config;
+    public StubDeviceConfigService(DeviceConfig config) => _config = config;
+    public Task<List<DeviceConfig>> GetConfigs() => Task.FromResult(new List<DeviceConfig> { _config });
+}
+
+internal class StubPlcDriverFactory : IPlcDriverFactory
+{
+    public DeviceTcpNet Create(DeviceConfig config)
+    {
+        var client = new ModbusTcpNet(config.Host, config.Port, 1);
+        client.ConnectServer();
+        return client;
+    }
+}
+
+internal class StubQueueManagerFactory : IQueueManagerFactory
+{
+    public StubQueueManager Manager { get; private set; }
+    public IQueueManager Create(DeviceConfig config)
+    {
+        Manager = new StubQueueManager();
+        return Manager;
+    }
+}
+
+internal class StubQueueManager : IQueueManager
+{
+    public readonly List<DataMessage> Messages = new();
+    public void EnqueueData(DataMessage dataMessage) => Messages.Add(dataMessage);
+    public void Dispose() { }
+}
+
+internal class StubMessageService : IMessageService
+{
+    public Task SendAsync(string message) => Task.CompletedTask;
+}

--- a/DataAcquisition.Core.Tests/DataAcquisitions/TriggerTests.cs
+++ b/DataAcquisition.Core.Tests/DataAcquisitions/TriggerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using DataAcquisition.Core.DataAcquisitions;
+using DataAcquisition.Core.DeviceConfigs;
+using DataAcquisition.Core.QueueManagers;
+using DataAcquisition.Core.Messages;
+using DataAcquisition.Core.Communication;
+
+namespace DataAcquisition.Core.Tests.DataAcquisitions;
+
+public class TriggerTests
+{
+    private readonly DataAcquisitionService _service;
+
+    public TriggerTests()
+    {
+        _service = new DataAcquisitionService(new StubDeviceConfigService(), new StubPlcDriverFactory(), new StubQueueManagerFactory(), new StubMessageService());
+    }
+
+    [Fact]
+    public void ShouldSample_WhenPrevNull_ReturnsTrue()
+    {
+        foreach (TriggerMode mode in Enum.GetValues(typeof(TriggerMode)))
+        {
+            Assert.True(_service.ShouldSample(mode, null, 1));
+        }
+    }
+
+    [Fact]
+    public void Always_TriggerReturnsTrue()
+    {
+        Assert.True(_service.ShouldSample(TriggerMode.Always, 1, 1));
+        Assert.True(_service.ShouldSample(TriggerMode.Always, 2, 5));
+    }
+
+    [Theory]
+    [InlineData(1, 2, true)]
+    [InlineData(2, 1, false)]
+    public void ValueIncrease_DetectsIncrease(int prev, int curr, bool expected)
+    {
+        Assert.Equal(expected, _service.ShouldSample(TriggerMode.ValueIncrease, prev, curr));
+    }
+
+    [Theory]
+    [InlineData(2, 1, true)]
+    [InlineData(1, 2, false)]
+    public void ValueDecrease_DetectsDecrease(int prev, int curr, bool expected)
+    {
+        Assert.Equal(expected, _service.ShouldSample(TriggerMode.ValueDecrease, prev, curr));
+    }
+
+    [Theory]
+    [InlineData(0, 1, true)]
+    [InlineData(1, 1, false)]
+    public void RisingEdge_DetectsTransition(int prev, int curr, bool expected)
+    {
+        Assert.Equal(expected, _service.ShouldSample(TriggerMode.RisingEdge, prev, curr));
+    }
+
+    [Theory]
+    [InlineData(1, 0, true)]
+    [InlineData(0, 0, false)]
+    public void FallingEdge_DetectsTransition(int prev, int curr, bool expected)
+    {
+        Assert.Equal(expected, _service.ShouldSample(TriggerMode.FallingEdge, prev, curr));
+    }
+}
+
+internal class StubDeviceConfigService : IDeviceConfigService
+{
+    public Task<List<DeviceConfig>> GetConfigs() => Task.FromResult(new List<DeviceConfig>());
+}
+
+internal class StubPlcDriverFactory : IPlcDriverFactory
+{
+    public DeviceTcpNet Create(DeviceConfig config) => null;
+}
+
+internal class StubQueueManagerFactory : IQueueManagerFactory
+{
+    public IQueueManager Create(DeviceConfig config) => new StubQueueManager();
+}
+
+internal class StubQueueManager : IQueueManager
+{
+    public void EnqueueData(DataMessage dataMessage) { }
+    public void Dispose() { }
+}
+
+internal class StubMessageService : IMessageService
+{
+    public Task SendAsync(string message) => Task.CompletedTask;
+}

--- a/DataAcquisition.Core.Tests/Utils/DataTypeUtilsTests.cs
+++ b/DataAcquisition.Core.Tests/Utils/DataTypeUtilsTests.cs
@@ -1,0 +1,30 @@
+using DataAcquisition.Core.Utils;
+using Xunit;
+
+namespace DataAcquisition.Core.Tests.Utils;
+
+public class DataTypeUtilsTests
+{
+    [Theory]
+    [InlineData((ushort)1)]
+    [InlineData((uint)1)]
+    [InlineData((ulong)1)]
+    [InlineData((short)1)]
+    [InlineData(1)]
+    [InlineData((long)1)]
+    [InlineData(1f)]
+    [InlineData(1d)]
+    public void IsNumberType_ReturnsTrueForNumericTypes(object value)
+    {
+        Assert.True(DataTypeUtils.IsNumberType(value));
+    }
+
+    [Theory]
+    [InlineData("string")]
+    [InlineData(true)]
+    [InlineData('c')]
+    public void IsNumberType_ReturnsFalseForNonNumericTypes(object value)
+    {
+        Assert.False(DataTypeUtils.IsNumberType(value));
+    }
+}

--- a/DataAcquisition.Core.Tests/Utils/Sha256UtilsTests.cs
+++ b/DataAcquisition.Core.Tests/Utils/Sha256UtilsTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using DataAcquisition.Core.Utils;
+using Xunit;
+
+namespace DataAcquisition.Core.Tests.Utils;
+
+public class Sha256UtilsTests
+{
+    [Fact]
+    public void ComputeSha256HashForDictionary_ReturnsSameHashRegardlessOfKeyOrder()
+    {
+        var dict1 = new Dictionary<string, object> { ["a"] = 1, ["b"] = 2 };
+        var dict2 = new Dictionary<string, object> { ["b"] = 2, ["a"] = 1 };
+
+        var hash1 = Sha256Utils.ComputeSha256HashForDictionary(dict1);
+        var hash2 = Sha256Utils.ComputeSha256HashForDictionary(dict2);
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ComputeSha256HashForDictionary_ReturnsExpectedHash()
+    {
+        var dict = new Dictionary<string, object> { ["b"] = 2, ["a"] = 1 };
+        var expected = "43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777";
+
+        var hash = Sha256Utils.ComputeSha256HashForDictionary(dict);
+
+        Assert.Equal(expected, hash);
+    }
+}

--- a/DataAcquisition.Core/AssemblyInfo.cs
+++ b/DataAcquisition.Core/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DataAcquisition.Core.Tests")]

--- a/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
+++ b/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
@@ -192,7 +192,7 @@ namespace DataAcquisition.Core.DataAcquisitions
         /// <param name="prev"></param>
         /// <param name="curr"></param>
         /// <returns></returns>
-        private bool ShouldSample(TriggerMode mode, object prev, object curr)
+        internal bool ShouldSample(TriggerMode mode, object prev, object curr)
         {
             if (prev == null) return true;
             decimal p = Convert.ToDecimal(prev);

--- a/DataAcquisition.sln
+++ b/DataAcquisition.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAcquisition.Core", "Dat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAcquisition.Gateway", "DataAcquisition.Gateway\DataAcquisition.Gateway.csproj", "{9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAcquisition.Core.Tests", "DataAcquisition.Core.Tests\DataAcquisition.Core.Tests.csproj", "{9BD9EFA2-DAD0-4127-A201-9AF8DCE967F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,7 +18,11 @@ Global
 		{C1ABCED8-9BEE-45FA-BB8B-5B763432799E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9E98A827-32FA-4FBA-9E75-6B3973DC8A7D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9BD9EFA2-DAD0-4127-A201-9AF8DCE967F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9BD9EFA2-DAD0-4127-A201-9AF8DCE967F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9BD9EFA2-DAD0-4127-A201-9AF8DCE967F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9BD9EFA2-DAD0-4127-A201-9AF8DCE967F4}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- simulate Modbus TCP server to validate data acquisition service
- verify trigger evaluation across all modes without reflection exposure
- expand Modbus integration tests to cover all trigger modes

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && bash dotnet-install.sh --version 8.0.100` *(fails: CONNECT tunnel failed, response 403)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aee1ee22c832e9ec42c4292995f1b