### PR TITLE
refactor: abstract PLC client

### DIFF
--- a/DataAcquisition.Core/Communication/HslPlcClient.cs
+++ b/DataAcquisition.Core/Communication/HslPlcClient.cs
@@ -1,0 +1,99 @@
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using HslCommunication.Core.Device;
+
+namespace DataAcquisition.Core.Communication;
+
+/// <summary>
+/// 基于 HslCommunication 的 PLC 客户端适配器
+/// </summary>
+public class HslPlcClient : IPlcClient
+{
+    private readonly DeviceTcpNet _device;
+
+    public HslPlcClient(DeviceTcpNet device)
+    {
+        _device = device;
+    }
+
+    public Task ConnectCloseAsync() => _device.ConnectCloseAsync();
+
+    public IPStatus IpAddressPing() => _device.IpAddressPing();
+
+    public async Task<PlcWriteResult> WriteAsync(string address, int value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new PlcWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public PlcReadResult Read(string address, ushort length)
+    {
+        var res = _device.Read(address, length);
+        return new PlcReadResult
+        {
+            IsSuccess = res.IsSuccess,
+            Content = res.Content ?? System.Array.Empty<byte>(),
+            Message = res.Message
+        };
+    }
+
+    public ushort ReadUInt16(string address)
+    {
+        var res = _device.ReadUInt16(address, 1);
+        return res.Content[0];
+    }
+
+    public uint ReadUInt32(string address)
+    {
+        var res = _device.ReadUInt32(address, 1);
+        return res.Content[0];
+    }
+
+    public ulong ReadUInt64(string address)
+    {
+        var res = _device.ReadUInt64(address, 1);
+        return res.Content[0];
+    }
+
+    public short ReadInt16(string address)
+    {
+        var res = _device.ReadInt16(address, 1);
+        return res.Content[0];
+    }
+
+    public int ReadInt32(string address)
+    {
+        var res = _device.ReadInt32(address, 1);
+        return res.Content[0];
+    }
+
+    public long ReadInt64(string address)
+    {
+        var res = _device.ReadInt64(address, 1);
+        return res.Content[0];
+    }
+
+    public float ReadFloat(string address)
+    {
+        var res = _device.ReadFloat(address, 1);
+        return res.Content[0];
+    }
+
+    public double ReadDouble(string address)
+    {
+        var res = _device.ReadDouble(address, 1);
+        return res.Content[0];
+    }
+
+    public ushort TransUInt16(byte[] buffer, int index) => _device.ByteTransform.TransUInt16(buffer, index);
+    public uint TransUInt32(byte[] buffer, int index) => _device.ByteTransform.TransUInt32(buffer, index);
+    public ulong TransUInt64(byte[] buffer, int index) => _device.ByteTransform.TransUInt64(buffer, index);
+    public short TransInt16(byte[] buffer, int index) => _device.ByteTransform.TransInt16(buffer, index);
+    public int TransInt32(byte[] buffer, int index) => _device.ByteTransform.TransInt32(buffer, index);
+    public long TransInt64(byte[] buffer, int index) => _device.ByteTransform.TransInt64(buffer, index);
+    public float TransSingle(byte[] buffer, int index) => _device.ByteTransform.TransSingle(buffer, index);
+    public double TransDouble(byte[] buffer, int index) => _device.ByteTransform.TransDouble(buffer, index);
+    public string TransString(byte[] buffer, int index, int length, Encoding encoding) => _device.ByteTransform.TransString(buffer, index, length, encoding);
+    public bool TransBool(byte[] buffer, int index) => _device.ByteTransform.TransBool(buffer, index);
+}

--- a/DataAcquisition.Core/Communication/IPlcClient.cs
+++ b/DataAcquisition.Core/Communication/IPlcClient.cs
@@ -1,0 +1,74 @@
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAcquisition.Core.Communication;
+
+/// <summary>
+/// PLC 客户端通用接口，封装具体协议实现。
+/// </summary>
+public interface IPlcClient
+{
+    /// <summary>
+    /// 关闭连接。
+    /// </summary>
+    Task ConnectCloseAsync();
+
+    /// <summary>
+    /// Ping 设备 IP。
+    /// </summary>
+    IPStatus IpAddressPing();
+
+    /// <summary>
+    /// 写寄存器。
+    /// </summary>
+    /// <param name="address">寄存器地址</param>
+    /// <param name="value">值</param>
+    Task<PlcWriteResult> WriteAsync(string address, int value);
+
+    /// <summary>
+    /// 批量读取原始数据。
+    /// </summary>
+    /// <param name="address">起始地址</param>
+    /// <param name="length">长度</param>
+    PlcReadResult Read(string address, ushort length);
+
+    ushort ReadUInt16(string address);
+    uint ReadUInt32(string address);
+    ulong ReadUInt64(string address);
+    short ReadInt16(string address);
+    int ReadInt32(string address);
+    long ReadInt64(string address);
+    float ReadFloat(string address);
+    double ReadDouble(string address);
+
+    ushort TransUInt16(byte[] buffer, int index);
+    uint TransUInt32(byte[] buffer, int index);
+    ulong TransUInt64(byte[] buffer, int index);
+    short TransInt16(byte[] buffer, int index);
+    int TransInt32(byte[] buffer, int index);
+    long TransInt64(byte[] buffer, int index);
+    float TransSingle(byte[] buffer, int index);
+    double TransDouble(byte[] buffer, int index);
+    string TransString(byte[] buffer, int index, int length, Encoding encoding);
+    bool TransBool(byte[] buffer, int index);
+}
+
+/// <summary>
+/// 读取结果
+/// </summary>
+public class PlcReadResult
+{
+    public bool IsSuccess { get; set; }
+    public byte[] Content { get; set; } = System.Array.Empty<byte>();
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// 写入结果
+/// </summary>
+public class PlcWriteResult
+{
+    public bool IsSuccess { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/DataAcquisition.Core/Communication/IPlcDriverFactory.cs
+++ b/DataAcquisition.Core/Communication/IPlcDriverFactory.cs
@@ -1,16 +1,14 @@
-﻿using HslCommunication.Core.Device;
-
 namespace DataAcquisition.Core.Communication;
 
 /// <summary>
-/// <see cref="DeviceTcpNet"/> 工厂
+/// PLC 客户端工厂
 /// </summary>
 public interface IPlcDriverFactory
 {
     /// <summary>
-    /// 创建
+    /// 创建对应协议的 PLC 客户端
     /// </summary>
-    /// <param name="config"></param>
-    /// <returns></returns>
-    DeviceTcpNet Create(DeviceConfig config);
+    /// <param name="config">设备配置</param>
+    /// <returns>PLC 客户端</returns>
+    IPlcClient Create(DeviceConfig config);
 }

--- a/DataAcquisition.Core/Communication/PlcDriverFactory.cs
+++ b/DataAcquisition.Core/Communication/PlcDriverFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using HslCommunication.Core;
 using HslCommunication.Core.Device;
 using HslCommunication.Profinet.Inovance;
@@ -8,21 +8,21 @@ namespace DataAcquisition.Core.Communication;
 
 public class PlcDriverFactory : IPlcDriverFactory
 {
-    public DeviceTcpNet Create(DeviceConfig config)
+    public IPlcClient Create(DeviceConfig config)
     {
-        return config.DriverType switch
+        DeviceTcpNet device = config.DriverType switch
         {
             "MelsecA1ENet" => new MelsecA1ENet(config.Host, config.Port)
             {
                 ReceiveTimeOut = 2000,
                 ConnectTimeOut = 2000
             },
-            "MelsecA1EAsciiNet" =>new MelsecA1EAsciiNet(config.Host, config.Port) 
+            "MelsecA1EAsciiNet" => new MelsecA1EAsciiNet(config.Host, config.Port)
             {
                 ReceiveTimeOut = 2000,
                 ConnectTimeOut = 2000
             },
-            "InovanceTcpNet"=> new InovanceTcpNet(config.Host, config.Port)
+            "InovanceTcpNet" => new InovanceTcpNet(config.Host, config.Port)
             {
                 ReceiveTimeOut = 2000,
                 ConnectTimeOut = 2000,
@@ -34,5 +34,7 @@ public class PlcDriverFactory : IPlcDriverFactory
             },
             _ => throw new ArgumentException("Unsupported plc driver type", nameof(config.DriverType))
         };
+
+        return new HslPlcClient(device);
     }
 }


### PR DESCRIPTION
## Summary
- add `IPlcClient` interface and result models to hide HslCommunication specifics
- provide `HslPlcClient` adapter and update driver factory to return it
- refactor data acquisition service to use new PLC abstraction

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c58a4938832e8bca5b84dd207a6e