### PR TITLE
docs: restructure bilingual readme with language toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,65 @@
-# PLC 数据采集系统
+# PLC Data Acquisition System / PLC 数据采集系统
 
-## 📌 项目概述
-
-本项目旨在通过动态收集来自 PLC（可编程逻辑控制器）的数据，为用户提供实时监控和分析工业设备运行状态的能力。支持多种 PLC 类型、实时数据采集、消息队列、高效数据存储等功能，适用于工业自动化过程中的监控与控制、设备性能分析及故障诊断。
+[English](#english) | [中文](#中文)
 
 ---
 
-## 🚀 核心功能
+## English
 
-- **高效通讯**：基于 Modbus TCP 协议，实现稳定的高效通讯
-- **消息队列**：支持数据缓存至 RabbitMQ、Kafka 或 本地消息队列，用于高并发数据采集
-- **数据存储**：支持存储至本地 SQLite 数据库或云存储
-- **日志记录**：支持自定义日志记录方式，便于问题排查与系统监控
-- **多 PLC 数据采集**：支持从多个 PLC 周期性地采集实时数据
-- **错误处理**：支持断线重连与超时重试，确保系统稳定运行
-- **频率控制**：可配置采集频率，支持毫秒级控制
-- **动态配置**：通过配置定义采集表、列名、频率，支持自定义数据点和采集方式
-- **多平台支持**：兼容 .NET Standard 2.0 和 2.1
-- **操作系统**：支持 Windows、Linux、macOS
+### Overview
+The PLC Data Acquisition System collects real-time operational data from programmable logic controllers and forwards the results to message queues and databases, supporting equipment monitoring, performance analysis, and fault diagnosis.
 
----
+### Key Features
+- Efficient communication using the Modbus TCP protocol ensures stable data exchange.
+- Message queues such as RabbitMQ, Kafka, or a local queue handle high-throughput acquisition results.
+- Data can be stored in SQLite or various cloud databases.
+- Custom logging strategies assist with troubleshooting and auditing.
+- Periodic acquisition from multiple PLCs is supported.
+- Disconnection and timeout retries are available to maintain stability.
+- Acquisition frequency is configurable down to milliseconds.
+- Configuration files define table structures, column names, and sampling frequency.
+- Compatible with .NET Standard 2.0/2.1 and runs on Windows, Linux, and macOS.
 
-## 🛠️ 安装与使用
+### Installation
 
-### 1️⃣ 克隆仓库
-
+#### Clone the repository
 ```bash
 git clone https://github.com/liuweichaox/DataAcquisition.git
 ```
 
-### 2️⃣ 配置文件
+#### Configuration files
+The `Configs` directory contains JSON files corresponding to database tables. Each file specifies PLC addresses, registers, data types, and other settings and may be modified as required.
 
-在 `Configs` 文件夹中，每个表对应一个独立的 JSON 文件，您可以根据需要修改配置。配置文件定义了 PLC 信息、寄存器地址、数据类型等内容。
+##### Configuration fields
+- **IsEnabled**: Whether the configuration is enabled.
+- **Code**: Identifier of the collector.
+- **Host**: PLC IP address.
+- **Port**: PLC port.
+- **DriverType**: Supported driver types include `MelsecA1ENet`, `MelsecA1EAsciiNet`, and `InovanceTcpNet`.
+- **HeartbeatMonitorRegister**: Register address for heartbeat monitoring.
+- **HeartbeatPollingInterval**: Heartbeat polling interval in milliseconds.
+- **StorageType**: Storage type (`SQLite`, `MySQL`, `PostgreSQL`, `SQLServer`).
+- **ConnectionString**: Database connection string.
+- **Modules**: Acquisition module definitions.
+  - **ChamberCode**: Channel identifier.
+  - **Trigger**: Trigger settings.
+    - **Mode**: `Always`, `ValueIncrease`, `ValueDecrease`, `RisingEdge`, `FallingEdge`.
+    - **Register**: Trigger register address.
+    - **DataType**: Data type of the trigger register.
+  - **BatchReadRegister**: Register for batch reading.
+  - **BatchReadLength**: Length of batch reads.
+  - **TableName**: Target database table.
+  - **BatchSize**: Batch size; `1` stores records individually.
+  - **DataPoints**: Data point configuration.
+    - **ColumnName**: Column name in the database.
+    - **Index**: Register index.
+    - **StringByteLength**: Byte length for string values.
+    - **Encoding**: Character encoding (`UTF8`, `GB2312`, `GBK`, `ASCII`).
+    - **DataType**: Data type of the register.
+    - **EvalExpression**: Expression for value conversion, e.g. `value / 1000.0`.
 
-#### 配置文件定义
-
-- **IsEnabled**: 是否启用该配置。
-- **Code**: 采集器代码，用于标识不同的采集器。
-- **Host**: PLC IP 地址。
-- **Port**: PLC 端口。
-- **DriverType**: PLC 驱动类型，支持 `MelsecA1ENet`、`MelsecA1EAsciiNet`、`InovanceTcpNet`。
-- **HeartbeatMonitorRegister**: 心跳监控寄存器地址。
-- **HeartbeatPollingInterval**: 心跳监控间隔（毫秒）。
-- **StorageType**: 数据存储类型，支持 `SQLite`、`MySQL`、`PostgreSQL`、`SQLServer`。
-- **ConnectionString**: 数据库连接字符串。
-- **Modules**: 采集模块配置。
-  - **ChamberCode**: 采集通道代码，用于标识不同的采集通道。
-  - **Trigger**: 触发配置。
-    - **Mode**: 触发模式，支持: `Always`：无条件触发、`ValueIncrease`：数值增加时触发、`ValueDecrease`：数值减少触发、`RisingEdge`：上升沿触发（表示从 0 变成 1 时采集）、`FallingEdge`：下降沿触发（表示从 1 变成 0 时采集）
-    - **Register**: 触发寄存器地址。
-    - **DataType**: 触发寄存器数据类型。
-  - **BatchReadRegister**: 批量读取寄存器地址。
-  - **BatchReadLength**: 批量读取寄存器长度。
-  - **TableName**: 数据库表名。
-  - **BatchSize**: 批量保存大小，1 表示单条保存。
-  - **DataPoints**: 数据点配置。
-    - **ColumnName**: 数据库列名。
-    - **Index**: 寄存器索引。
-    - **StringByteLength**: 字符串字节长度。
-    - **Encoding**: 字符串编码，支持 `UTF8`、`GB2312`、`GBK`、`ASCII`。
-    - **DataType**: 寄存器数据类型。
-    - **EvalExpression**: 数据转换表达式，支持简单的数学表达式，例如 `value / 1000.0`。
-
----
-
-**示例配置** (`Configs/M01_Metrics.json`):
+#### Sample configuration
+The file `Configs/M01_Metrics.json` illustrates a typical configuration.
 
 ```json
 {
@@ -144,43 +139,196 @@ git clone https://github.com/liuweichaox/DataAcquisition.git
 }
 ```
 
-## ⚙️ 配置 `DataAcquisition`
-
-在 `Startup.cs` 中配置 `IDataAcquisition` 实例，负责管理数据采集任务。
+### Application setup
+Register the `IDataAcquisition` instance in `Startup.cs` to manage acquisition tasks.
 
 ```csharp
-builder.Services.AddSingleton<IMessage, Message>(); // 消息服务
-builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>(); // 通讯工厂
-builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>(); // 数据存储工厂
-builder.Services.AddSingleton<IQueueFactory, QueueFactory>(); // 消息队列工厂
-builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>(); // 数据采集服务
-builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>(); // 数据处理服务
-builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>(); // 设备配置服务
+builder.Services.AddSingleton<IMessage, Message>();
+builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
+builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
+builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
+builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
+builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
 
-builder.Services.AddHostedService<DataAcquisitionHostedService>(); // 数据采集托管服务
+builder.Services.AddHostedService<DataAcquisitionHostedService>();
 ```
 
----
+### API
 
-## 📑 API 文档
+#### Get PLC connection status
+- `GET /api/DataAcquisition/GetPlcConnectionStatus`
 
-### 获取 PLC 连接状态
+The endpoint returns a dictionary of PLC connection states.
 
-- **GET** `/api/DataAcquisition/GetPlcConnectionStatus`
-- **返回**：`PLC 连接状态字典`
+### Contribution
+Contributions are accepted via Pull Requests. Ensure all relevant tests pass and avoid breaking changes before submission.
 
----
-
-## 🤝 贡献
-
-如果您想为该项目贡献代码，欢迎提交 Pull Request！在提交之前，请确保代码通过了所有单元测试，并且没有引入任何破坏性变化。
-
-## 📄 许可
-
-本项目使用 MIT 许可证，详情请参阅 [LICENSE](LICENSE) 文件。
+### License
+This project is licensed under the MIT License; see [LICENSE](LICENSE) for details.
 
 ---
 
-感谢您使用 PLC 数据采集系统！如有问题，欢迎提出 issue 或进行讨论。 🎉
+## 中文
 
----
+### 概述
+PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据，并将结果传递至消息队列和数据库，以支持工业设备监控、性能分析与故障诊断。
+
+### 核心功能
+- 高效通讯：基于 Modbus TCP 协议实现稳定的数据传输。
+- 消息队列：可将采集结果写入 RabbitMQ、Kafka 或本地队列以处理高并发。
+- 数据存储：支持本地 SQLite 数据库及多种云端数据库。
+- 日志记录：允许自定义日志策略，便于排查和审计。
+- 多 PLC 数据采集：支持同时周期性读取多个 PLC。
+- 错误处理：提供断线重连和超时重试机制。
+- 频率控制：采集频率可配置，最低支持毫秒级。
+- 动态配置：通过配置文件定义表结构、列名和频率。
+- 多平台支持：兼容 .NET Standard 2.0 与 2.1，运行于 Windows、Linux 和 macOS。
+
+### 安装
+
+#### 克隆仓库
+```bash
+git clone https://github.com/liuweichaox/DataAcquisition.git
+```
+
+#### 配置文件
+`Configs` 目录包含与数据库表对应的 JSON 文件。每个文件定义 PLC 地址、寄存器、数据类型等信息，可根据实际需求调整。
+
+##### 配置字段
+- **IsEnabled**：是否启用该配置。
+- **Code**：采集器标识。
+- **Host**：PLC IP 地址。
+- **Port**：PLC 端口。
+- **DriverType**：驱动类型，支持 `MelsecA1ENet`、`MelsecA1EAsciiNet`、`InovanceTcpNet`。
+- **HeartbeatMonitorRegister**：心跳监控寄存器地址。
+- **HeartbeatPollingInterval**：心跳轮询间隔（毫秒）。
+- **StorageType**：数据存储类型，支持 `SQLite`、`MySQL`、`PostgreSQL`、`SQLServer`。
+- **ConnectionString**：数据库连接字符串。
+- **Modules**：采集模块定义。
+  - **ChamberCode**：采集通道代码。
+  - **Trigger**：触发配置。
+    - **Mode**：触发模式，`Always`、`ValueIncrease`、`ValueDecrease`、`RisingEdge`、`FallingEdge`。
+    - **Register**：触发寄存器地址。
+    - **DataType**：触发寄存器数据类型。
+  - **BatchReadRegister**：批量读取寄存器地址。
+  - **BatchReadLength**：批量读取长度。
+  - **TableName**：数据库表名。
+  - **BatchSize**：批量保存大小，`1` 表示逐条保存。
+  - **DataPoints**：数据配置。
+    - **ColumnName**：数据库列名。
+    - **Index**：寄存器索引。
+    - **StringByteLength**：字符串字节长度。
+    - **Encoding**：编码方式，支持 `UTF8`、`GB2312`、`GBK`、`ASCII`。
+    - **DataType**：寄存器数据类型。
+    - **EvalExpression**：数值转换表达式，例如 `value / 1000.0`。
+
+#### 配置示例
+`Configs/M01_Metrics.json` 示例展示了典型配置方式。
+
+```json
+{
+  "IsEnabled": true,
+  "Code": "M01C123",
+  "Host": "192.168.1.110",
+  "Port": 4104,
+  "DriverType": "MelsecA1EAsciiNet",
+  "HeartbeatMonitorRegister": "D6061",
+  "HeartbeatPollingInterval": 2000,
+  "StorageType": "MySQL",
+  "ConnectionString": "Server=127.0.0.1;Database=daq;Uid=root;Pwd=123456;Connect Timeout=30;SslMode=None;",
+  "Modules": [
+    {
+      "ChamberCode": "M01C01",
+      "Trigger": {
+        "Mode": "Always",
+        "Register": null,
+        "DataType": null,
+        "PollInterval": 0
+      },
+      "BatchReadRegister": "D6000",
+      "BatchReadLength": 70,
+      "TableName": "m01c01_sensor",
+      "BatchSize": 1,
+      "DataPoints": [
+        {
+          "ColumnName": "up_temp",
+          "Index": 2,
+          "StringByteLength": 0,
+          "Encoding": null,
+          "DataType": "short",
+          "EvalExpression": ""
+        },
+        {
+          "ColumnName": "down_temp",
+          "Index": 4,
+          "StringByteLength": 0,
+          "Encoding": null,
+          "DataType": "short",
+          "EvalExpression": "value / 1000.0"
+        }
+      ]
+    },
+    {
+      "ChamberCode": "M01C02",
+      "Trigger": {
+        "Mode": "RisingEdge",
+        "Register": null,
+        "DataType": null,
+        "PollInterval": 0
+      },
+      "BatchReadRegister": "D6100",
+      "BatchReadLength": 200,
+      "TableName": "m01c02_sensor",
+      "BatchSize": 10,
+      "DataPoints": [
+        {
+          "ColumnName": "up_set_temp",
+          "Index": 2,
+          "StringByteLength": 0,
+          "Encoding": null,
+          "DataType": "short",
+          "EvalExpression": ""
+        },
+        {
+          "ColumnName": "down_set_temp",
+          "Index": 4,
+          "StringByteLength": 0,
+          "Encoding": null,
+          "DataType": "short",
+          "EvalExpression": "value / 1000.0"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 系统配置
+在 `Startup.cs` 中注册 `IDataAcquisition` 实例以管理采集任务。
+
+```csharp
+builder.Services.AddSingleton<IMessage, Message>();
+builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
+builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
+builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
+builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
+builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
+
+builder.Services.AddHostedService<DataAcquisitionHostedService>();
+```
+
+### API
+
+#### 获取 PLC 连接状态
+- `GET /api/DataAcquisition/GetPlcConnectionStatus`
+
+该接口返回各 PLC 连接状态的字典。
+
+### 贡献
+欢迎通过 Pull Request 提交改进。提交前请确保所有相关测试通过并避免引入破坏性修改。
+
+### 许可
+本项目采用 MIT 许可证，详情见 [LICENSE](LICENSE)。
+


### PR DESCRIPTION
## Summary
- separate README into standalone English and Chinese sections with a top-level language switch

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa08e94a50832e9ce15d5b36264728