### PR TITLE
docs: format config fields with tables

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -32,30 +32,48 @@ git clone https://github.com/liuweichaox/DataAcquisition.git
 The `DataAcquisition.Gateway/Configs` directory stores JSON files that correspond to database tables. Each file defines PLC addresses, registers, data types, and other settings and can be adjusted as needed.
 
 #### 📑 Configuration fields
-- **IsEnabled**: Whether the configuration is enabled.
-- **Code**: PLC identifier.
-- **Host**: PLC IP address.
-- **Port**: PLC port.
-- **HeartbeatMonitorRegister**: Register address for heartbeat monitoring.
-- **HeartbeatPollingInterval**: Heartbeat polling interval in milliseconds.
-- **ConnectionString**: Database connection string.
-- **Modules**: Acquisition modules.
-  - **ChamberCode**: Channel identifier.
-  - **Trigger**: Trigger settings.
-    - **Mode**: Trigger mode.
-    - **Register**: Trigger register address.
-    - **DataType**: Data type of the trigger register.
-  - **BatchReadRegister**: Start register for batch reading.
-  - **BatchReadLength**: Number of registers to read.
-  - **TableName**: Target database table.
-  - **BatchSize**: Number of records per batch (`1` inserts one by one).
-  - **DataPoints**: Data point configuration.
-    - **ColumnName**: Column name in the database.
-    - **Index**: Register index.
-    - **StringByteLength**: Byte length for string values.
-    - **Encoding**: Character encoding.
-    - **DataType**: Data type of the register.
-    - **EvalExpression**: Expression for value conversion, e.g. `value / 1000.0`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `IsEnabled` | `bool` | Whether the configuration is enabled. |
+| `Code` | `string` | PLC identifier. |
+| `Host` | `string` | PLC IP address. |
+| `Port` | `int` | PLC port. |
+| `HeartbeatMonitorRegister` | `string` | Register address for heartbeat monitoring. |
+| `HeartbeatPollingInterval` | `int` | Heartbeat polling interval in milliseconds. |
+| `ConnectionString` | `string` | Database connection string. |
+| `Modules` | `Module[]` | Acquisition modules. |
+
+##### Module
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ChamberCode` | `string` | Channel identifier. |
+| `Trigger` | `TriggerConfig` | Trigger settings. |
+| `BatchReadRegister` | `string` | Start register for batch reading. |
+| `BatchReadLength` | `int` | Number of registers to read. |
+| `TableName` | `string` | Target database table. |
+| `BatchSize` | `int` | Number of records per batch (`1` inserts one by one). |
+| `DataPoints` | `DataPoint[]` | Data point configuration. |
+
+##### TriggerConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Mode` | `string` | Trigger mode. |
+| `Register` | `string` | Trigger register address. |
+| `DataType` | `string` | Data type of the trigger register. |
+
+##### DataPoint
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ColumnName` | `string` | Column name in the database. |
+| `Index` | `int` | Register index. |
+| `StringByteLength` | `int` | Byte length for string values. |
+| `Encoding` | `string` | Character encoding. |
+| `DataType` | `string` | Data type of the register. |
+| `EvalExpression` | `string` | Expression for value conversion, e.g. `value / 1000.0`. |
 
 #### 📚 Enumeration reference
 - **Trigger.Mode**

--- a/README.md
+++ b/README.md
@@ -32,30 +32,48 @@ git clone https://github.com/liuweichaox/DataAcquisition.git
 `DataAcquisition.Gateway/Configs` 目录包含与数据库表对应的 JSON 文件。每个文件定义 PLC 地址、寄存器、数据类型等信息，可根据实际需求调整。
 
 #### 📑 配置字段
-- **IsEnabled**：是否启用该配置。
-- **Code**：PLC 编码。
-- **Host**：PLC IP 地址。
-- **Port**：PLC 通讯端口。
-- **HeartbeatMonitorRegister**：心跳监控寄存器地址。
-- **HeartbeatPollingInterval**：心跳轮询间隔（毫秒）。
-- **ConnectionString**：数据库连接字符串。
-- **Modules**：采集模块定义。
-  - **ChamberCode**：采集通道代码。
-  - **Trigger**：触发配置。
-    - **Mode**：触发模式。
-    - **Register**：触发寄存器地址。
-    - **DataType**：触发寄存器数据类型。
-  - **BatchReadRegister**：批量读取寄存器地址。
-  - **BatchReadLength**：批量读取长度。
-  - **TableName**：数据库表名。
-  - **BatchSize**：批量保存大小，`1` 表示逐条保存。
-  - **DataPoints**：数据配置。
-    - **ColumnName**：数据库列名。
-    - **Index**：寄存器索引。
-    - **StringByteLength**：字符串字节长度。
-    - **Encoding**：编码方式。
-    - **DataType**：寄存器数据类型。
-    - **EvalExpression**：数值转换表达式，例如 `value / 1000.0`。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `IsEnabled` | `bool` | 是否启用该配置。 |
+| `Code` | `string` | PLC 编码。 |
+| `Host` | `string` | PLC IP 地址。 |
+| `Port` | `int` | PLC 通讯端口。 |
+| `HeartbeatMonitorRegister` | `string` | 心跳监控寄存器地址。 |
+| `HeartbeatPollingInterval` | `int` | 心跳轮询间隔（毫秒）。 |
+| `ConnectionString` | `string` | 数据库连接字符串。 |
+| `Modules` | `Module[]` | 采集模块定义。 |
+
+##### Module
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `ChamberCode` | `string` | 采集通道代码。 |
+| `Trigger` | `TriggerConfig` | 触发配置。 |
+| `BatchReadRegister` | `string` | 批量读取寄存器地址。 |
+| `BatchReadLength` | `int` | 批量读取长度。 |
+| `TableName` | `string` | 数据库表名。 |
+| `BatchSize` | `int` | 批量保存大小，`1` 表示逐条保存。 |
+| `DataPoints` | `DataPoint[]` | 数据配置。 |
+
+##### TriggerConfig
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `Mode` | `string` | 触发模式。 |
+| `Register` | `string` | 触发寄存器地址。 |
+| `DataType` | `string` | 触发寄存器数据类型。 |
+
+##### DataPoint
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `ColumnName` | `string` | 数据库列名。 |
+| `Index` | `int` | 寄存器索引。 |
+| `StringByteLength` | `int` | 字符串字节长度。 |
+| `Encoding` | `string` | 编码方式。 |
+| `DataType` | `string` | 寄存器数据类型。 |
+| `EvalExpression` | `string` | 数值转换表达式，例如 `value / 1000.0`。 |
 
 #### 📚 枚举值说明
 - **Trigger.Mode**


### PR DESCRIPTION
## Summary
- present configuration fields and nested structures in tables for both language readmes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6a4d2f54832ea80ea16ec621f63b