### PR TITLE
docs: clarify DataType enumeration in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,8 +82,9 @@ The `DataAcquisition.Gateway/Configs` directory stores JSON files that correspon
   - `ValueDecrease`: sample when the register value decreases.
   - `RisingEdge`: sample on a rising edge (0 → 1).
   - `FallingEdge`: sample on a falling edge (1 → 0).
-- **DataType** (for `Trigger.DataType` and `DataPoints.DataType`)
-  - `ushort`, `uint`, `ulong`, `short`, `int`, `long`, `float`, `double`, `string`, `bool`.
+- **DataType**
+  - `Trigger.DataType`: `ushort`, `uint`, `ulong`, `short`, `int`, `long`, `float`, `double`.
+  - `DataPoints.DataType`: `ushort`, `uint`, `ulong`, `short`, `int`, `long`, `float`, `double`, `string`, `bool`.
 - **Encoding**
   - `UTF8`, `GB2312`, `GBK`, `ASCII`.
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ git clone https://github.com/liuweichaox/DataAcquisition.git
   - `ValueDecrease`：当寄存器值减少时采样。
   - `RisingEdge`：寄存器从 0 变为 1 时采样。
   - `FallingEdge`：寄存器从 1 变为 0 时采样。
-- **DataType**（用于 `Trigger.DataType` 和 `DataPoints.DataType`）
-  - `ushort`、`uint`、`ulong`、`short`、`int`、`long`、`float`、`double`、`string`、`bool`。
+- **DataType**
+  - `Trigger.DataType`：`ushort`、`uint`、`ulong`、`short`、`int`、`long`、`float`、`double`。
+  - `DataPoints.DataType`：`ushort`、`uint`、`ulong`、`short`、`int`、`long`、`float`、`double`、`string`、`bool`。
 - **Encoding**
   - `UTF8`、`GB2312`、`GBK`、`ASCII`。
 


### PR DESCRIPTION
## Summary
- clarify DataType support separately for trigger and data points in README files

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6d01409c832e830cba8cf158778e