### PR TITLE
Support multi-type writes in PLC communication

### DIFF
--- a/DataAcquisition.Core/Communication/ICommunication.cs
+++ b/DataAcquisition.Core/Communication/ICommunication.cs
@@ -23,8 +23,8 @@ public interface ICommunication
     /// 写寄存器。
     /// </summary>
     /// <param name="address">寄存器地址</param>
-    /// <param name="value">值</param>
-    Task<CommunicationWriteResult> WriteAsync(string address, int value);
+    /// <param name="value">写入值，支持多种数据类型</param>
+    Task<CommunicationWriteResult> WriteAsync(string address, object value);
 
     /// <summary>
     /// 批量读取原始数据。

--- a/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
+++ b/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
@@ -27,9 +27,49 @@ public class Communication : ICommunication
 
     public IPStatus IpAddressPing() => _device.IpAddressPing();
 
-    public async Task<CommunicationWriteResult> WriteAsync(string address, int value)
+    public async Task<CommunicationWriteResult> WriteAsync(string address, object value)
     {
-        var res = await _device.WriteAsync(address, value);
+        HslCommunication.OperateResult res;
+        switch (value)
+        {
+            case ushort v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case uint v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case ulong v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case short v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case int v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case long v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case float v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case double v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case string v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case bool v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            default:
+                return new CommunicationWriteResult
+                {
+                    IsSuccess = false,
+                    Message = $"Unsupported value type: {value?.GetType()}"
+                };
+        }
+
         return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
     }
 


### PR DESCRIPTION
## Summary
- allow `ICommunication.WriteAsync` to accept values of different types
- handle numeric, string, and boolean writes in the HslCommunication adapter
- drop previously added HTTP write endpoint to keep API minimal

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83ef28ac832eab887df1722ff4da