### PR TITLE
Add API for writing to PLC registers

### DIFF
--- a/DataAcquisition.Core/Communication/ICommunication.cs
+++ b/DataAcquisition.Core/Communication/ICommunication.cs
@@ -23,8 +23,8 @@ public interface ICommunication
     /// 写寄存器。
     /// </summary>
     /// <param name="address">寄存器地址</param>
-    /// <param name="value">值</param>
-    Task<CommunicationWriteResult> WriteAsync(string address, int value);
+    /// <param name="value">写入值，支持多种数据类型</param>
+    Task<CommunicationWriteResult> WriteAsync(string address, object value);
 
     /// <summary>
     /// 批量读取原始数据。

--- a/DataAcquisition.Core/DataAcquisitions/IDataAcquisitionService.cs
+++ b/DataAcquisition.Core/DataAcquisitions/IDataAcquisitionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DataAcquisition.Core.Communication;
 
 namespace DataAcquisition.Core.DataAcquisitions;
 
@@ -25,4 +26,14 @@ public interface IDataAcquisitionService : IDisposable
     /// </summary>
     /// <returns></returns>
     SortedDictionary<string, bool> GetPlcConnectionStatus();
+
+    /// <summary>
+    /// 写入 PLC 寄存器
+    /// </summary>
+    /// <param name="plcCode">PLC 编号</param>
+    /// <param name="address">寄存器地址</param>
+    /// <param name="value">写入值</param>
+    /// <param name="dataType">数据类型</param>
+    /// <returns>写入结果</returns>
+    Task<CommunicationWriteResult> WritePlcAsync(string plcCode, string address, object value, string dataType);
 }

--- a/DataAcquisition.Gateway/Controllers/DataAcquisitionController.cs
+++ b/DataAcquisition.Gateway/Controllers/DataAcquisitionController.cs
@@ -1,4 +1,5 @@
 ﻿using DataAcquisition.Core.DataAcquisitions;
+using DataAcquisition.Gateway.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DataAcquisition.Gateway.Controllers;
@@ -24,5 +25,21 @@ public class DataAcquisitionController: ControllerBase
     {
         var plcConnectionStatus = _dataAcquisitionService.GetPlcConnectionStatus();
         return Ok(plcConnectionStatus);
+    }
+
+    /// <summary>
+    /// 写入 PLC 寄存器
+    /// </summary>
+    /// <param name="request">写入请求</param>
+    [HttpPost]
+    public async Task<IActionResult> WriteRegister([FromBody] PlcWriteRequest request)
+    {
+        var result = await _dataAcquisitionService.WritePlcAsync(request.PlcCode, request.Address, request.Value, request.DataType);
+        if (result.IsSuccess)
+        {
+            return Ok(result);
+        }
+
+        return BadRequest(result);
     }
 }

--- a/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
+++ b/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
@@ -27,9 +27,49 @@ public class Communication : ICommunication
 
     public IPStatus IpAddressPing() => _device.IpAddressPing();
 
-    public async Task<CommunicationWriteResult> WriteAsync(string address, int value)
+    public async Task<CommunicationWriteResult> WriteAsync(string address, object value)
     {
-        var res = await _device.WriteAsync(address, value);
+        HslCommunication.OperateResult res;
+        switch (value)
+        {
+            case ushort v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case uint v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case ulong v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case short v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case int v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case long v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case float v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case double v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case string v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            case bool v:
+                res = await _device.WriteAsync(address, v);
+                break;
+            default:
+                return new CommunicationWriteResult
+                {
+                    IsSuccess = false,
+                    Message = $"Unsupported value type: {value?.GetType()}"
+                };
+        }
+
         return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
     }
 

--- a/DataAcquisition.Gateway/Models/PlcWriteRequest.cs
+++ b/DataAcquisition.Gateway/Models/PlcWriteRequest.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace DataAcquisition.Gateway.Models;
+
+public class PlcWriteRequest
+{
+    public string PlcCode { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string DataType { get; set; } = string.Empty;
+    public JsonElement Value { get; set; }
+}
+

--- a/README.en.md
+++ b/README.en.md
@@ -41,7 +41,6 @@ Host: string                    # PLC IP address
 Port: number                    # PLC communication port
 HeartbeatMonitorRegister: string # [Optional] register for heartbeat monitoring
 HeartbeatPollingInterval: number # [Optional] heartbeat polling interval (milliseconds)
-ConnectionString: string        # Database connection string
 Modules:
   - ChamberCode: string         # Channel identifier
     Trigger:
@@ -90,7 +89,6 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
   "Port": 4104,
   "HeartbeatMonitorRegister": "D6061",
   "HeartbeatPollingInterval": 2000,
-  "ConnectionString": "Server=127.0.0.1;Database=daq;Uid=root;Pwd=123456;Connect Timeout=30;SslMode=None;",
   "Modules": [
     {
       "ChamberCode": "M01C01",
@@ -176,6 +174,20 @@ builder.Services.AddHostedService<DataAcquisitionHostedService>();
 - `GET /api/DataAcquisition/GetPlcConnectionStatus`
 
 The endpoint returns a dictionary of PLC connection states.
+
+### ✍️ Write to PLC register
+- `POST /api/DataAcquisition/WriteRegister`
+
+Request example (specify `dataType` to indicate the value type):
+
+```json
+{
+  "plcCode": "PLC01",
+  "address": "D100",
+  "dataType": "short",
+  "value": 1
+}
+```
 
 ## 🤝 Contribution
 Contributions are welcome via Pull Requests. Ensure all relevant tests pass and avoid introducing breaking changes.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Host: string                    # PLC IP 地址
 Port: number                    # PLC 通讯端口
 HeartbeatMonitorRegister: string # [可选] 心跳监控寄存器地址
 HeartbeatPollingInterval: number # [可选] 心跳轮询间隔（毫秒）
-ConnectionString: string        # 数据库连接字符串
 Modules:                        # 采集模块配置数组
   - ChamberCode: string         # 采集通道编码
     Trigger:                    # 触发配置
@@ -90,7 +89,6 @@ Modules:                        # 采集模块配置数组
   "Port": 4104,
   "HeartbeatMonitorRegister": "D6061",
   "HeartbeatPollingInterval": 2000,
-  "ConnectionString": "Server=127.0.0.1;Database=daq;Uid=root;Pwd=123456;Connect Timeout=30;SslMode=None;",
   "Modules": [
     {
       "ChamberCode": "M01C01",
@@ -176,6 +174,20 @@ builder.Services.AddHostedService<DataAcquisitionHostedService>();
 - `GET /api/DataAcquisition/GetPlcConnectionStatus`
 
 该接口返回各 PLC 连接状态的字典。
+
+### ✍️ 写入 PLC 寄存器
+- `POST /api/DataAcquisition/WriteRegister`
+
+请求示例（通过 `dataType` 指定写入值类型）：
+
+```json
+{
+  "plcCode": "PLC01",
+  "address": "D100",
+  "dataType": "short",
+  "value": 1
+}
+```
 
 ## 🤝 贡献
 欢迎通过 Pull Request 提交改进。提交前请确保所有相关测试通过并避免引入破坏性修改。


### PR DESCRIPTION
## Summary
- allow PLC write operations to accept multiple data types
- add `dataType` field and flexible `value` in write request
- document new request format in English and Chinese READMEs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed / 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83ef28ac832eab887df1722ff4da