### PR TITLE
feat: add PLC type config and document data operations

### DIFF
--- a/DataAcquisition.Core/Models/DeviceConfig.cs
+++ b/DataAcquisition.Core/Models/DeviceConfig.cs
@@ -29,6 +29,12 @@ public class DeviceConfig
     public ushort Port { get; set; }
 
     /// <summary>
+    /// PLC 类型
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public PlcType Type { get; set; }
+
+    /// <summary>
     /// 心跳检测地址
     /// </summary>
     public string HeartbeatMonitorRegister { get; set; }

--- a/DataAcquisition.Core/Models/PlcType.cs
+++ b/DataAcquisition.Core/Models/PlcType.cs
@@ -1,0 +1,18 @@
+namespace DataAcquisition.Core.Models;
+
+/// <summary>
+/// PLC 类型
+/// </summary>
+public enum PlcType
+{
+    /// <summary>
+    /// 三菱
+    /// </summary>
+    Mitsubishi,
+
+    /// <summary>
+    /// 汇川
+    /// </summary>
+    Inovance
+}
+

--- a/DataAcquisition.Gateway/Configs/M01C123.json
+++ b/DataAcquisition.Gateway/Configs/M01C123.json
@@ -3,6 +3,7 @@
   "Code": "M01C123",
   "Host": "192.168.1.110",
   "Port": 4104,
+  "Type": "Mitsubishi",
   "HeartbeatMonitorRegister": "D6061",
   "HeartbeatPollingInterval": 2000,
   "Modules": [

--- a/README.en.md
+++ b/README.en.md
@@ -39,6 +39,7 @@ IsEnabled: true                 # Enable this configuration
 Code: string                    # PLC identifier
 Host: string                    # PLC IP address
 Port: number                    # PLC communication port
+Type: Mitsubishi|Inovance       # PLC type
 HeartbeatMonitorRegister: string # [Optional] register for heartbeat monitoring
 HeartbeatPollingInterval: number # [Optional] heartbeat polling interval (milliseconds)
 Modules:
@@ -51,6 +52,7 @@ Modules:
     BatchReadLength: int        # Number of registers to read
     TableName: string           # Target database table
     BatchSize: int              # Number of records per batch (1 inserts one by one)
+    Operation: Insert|Update    # Data operation type
     DataPoints:
       - ColumnName: string      # Column name in the database
         Index: int              # Register index
@@ -61,6 +63,9 @@ Modules:
 ```
 
 #### 📚 Enum descriptions
+- **Type**
+  - `Mitsubishi`: Mitsubishi PLC
+  - `Inovance`: Inovance PLC
 - **Trigger.Mode**
   - `Always`: always sample
   - `ValueIncrease`: sample when the register value increases
@@ -74,6 +79,9 @@ Modules:
   - `string`, `bool` (DataPoints only)
 - **Encoding**
   - `UTF8`, `GB2312`, `GBK`, `ASCII`
+- **Module.Operation**
+  - `Insert`: insert a new record
+  - `Update`: update an existing record
 
 #### ⚖️ EvalExpression usage
 `EvalExpression` converts the raw register value before storage. The expression may reference the variable `value` representing the raw number and can use basic arithmetic. For example, `"value / 1000.0"` scales the value; leave it empty to skip conversion.
@@ -87,6 +95,7 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
   "Code": "M01C123",
   "Host": "192.168.1.110",
   "Port": 4104,
+  "Type": "Mitsubishi",
   "HeartbeatMonitorRegister": "D6061",
   "HeartbeatPollingInterval": 2000,
   "Modules": [
@@ -101,6 +110,7 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
       "BatchReadLength": 70,
       "TableName": "m01c01_sensor",
       "BatchSize": 1,
+      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_temp",
@@ -131,6 +141,7 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
       "BatchReadLength": 200,
       "TableName": "m01c02_sensor",
       "BatchSize": 10,
+      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_set_temp",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ IsEnabled: true                 # 是否启用
 Code: string                    # PLC 编码
 Host: string                    # PLC IP 地址
 Port: number                    # PLC 通讯端口
+Type: Mitsubishi|Inovance       # PLC 类型
 HeartbeatMonitorRegister: string # [可选] 心跳监控寄存器地址
 HeartbeatPollingInterval: number # [可选] 心跳轮询间隔（毫秒）
 Modules:                        # 采集模块配置数组
@@ -51,6 +52,7 @@ Modules:                        # 采集模块配置数组
     BatchReadLength: int        # 批量读取长度
     TableName: string           # 数据库表名
     BatchSize: int              # 批量保存大小，1 表示逐条保存
+    Operation: Insert|Update    # 数据操作类型
     DataPoints:                 # 数据配置
       - ColumnName: string      # 数据库列名
         Index: int              # 寄存器索引
@@ -61,6 +63,9 @@ Modules:                        # 采集模块配置数组
 ```
 
 #### 📚 枚举值说明
+- **Type**
+  - `Mitsubishi`：三菱 PLC。
+  - `Inovance`：汇川 PLC。
 - **Trigger.Mode**
   - `Always`：始终采样。
   - `ValueIncrease`：寄存器值增加时采样。
@@ -74,6 +79,9 @@ Modules:                        # 采集模块配置数组
   - `string`、`bool`（仅用于 DataPoints）。
 - **Encoding**
   - `UTF8`、`GB2312`、`GBK`、`ASCII`。
+- **Module.Operation**
+  - `Insert`：插入新记录。
+  - `Update`：更新已有记录。
 
 #### ⚖️ EvalExpression 用法
 `EvalExpression` 用于在写入数据库前对寄存器读数进行转换。表达式中可使用变量 `value` 表示原始值，如 `"value / 1000.0"`。留空字符串则不进行任何转换。
@@ -87,6 +95,7 @@ Modules:                        # 采集模块配置数组
   "Code": "M01C123",
   "Host": "192.168.1.110",
   "Port": 4104,
+  "Type": "Mitsubishi",
   "HeartbeatMonitorRegister": "D6061",
   "HeartbeatPollingInterval": 2000,
   "Modules": [
@@ -101,6 +110,7 @@ Modules:                        # 采集模块配置数组
       "BatchReadLength": 70,
       "TableName": "m01c01_sensor",
       "BatchSize": 1,
+      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_temp",
@@ -131,6 +141,7 @@ Modules:                        # 采集模块配置数组
       "BatchReadLength": 200,
       "TableName": "m01c02_sensor",
       "BatchSize": 10,
+      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_set_temp",


### PR DESCRIPTION
## Summary
- support specifying PLC type in device configuration
- document data operation semantics in README
- update example configuration for new PLC types

## Testing
- `dotnet build DataAcquisition.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8e586afc832e91b6b5b3d3856293