### PR TITLE
feat: make trigger operation and times configurable

### DIFF
--- a/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
+++ b/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
@@ -119,7 +119,7 @@ namespace DataAcquisition.Core.DataAcquisitions
                                         {
                                             try
                                             {
-                                                var operation = module.Operation;
+                                                var operation = trigger.Operation;
                                                 var key = $"{config.Code}:{module.TableName}";
                                                 var timestamp = DateTime.Now;
                                                 var dataMessage = new DataMessage(timestamp, module.TableName, module.BatchSize, module.DataPoints, operation);
@@ -132,14 +132,23 @@ namespace DataAcquisition.Core.DataAcquisitions
                                                         var value = TransValue(client, buffer, dataPoint.Index, dataPoint.StringByteLength, dataPoint.DataType, dataPoint.Encoding);
                                                         dataMessage.Values[dataPoint.ColumnName] = value;
                                                     }
-                                                    dataMessage.Values["StartTime"] = timestamp;
-                                                    _lastStartTimes[key] = timestamp;
+                                                    if (!string.IsNullOrEmpty(trigger.StartTimeName))
+                                                    {
+                                                        dataMessage.Values[trigger.StartTimeName] = timestamp;
+                                                        _lastStartTimes[key] = timestamp;
+                                                    }
                                                     _queue.PublishAsync(dataMessage);
                                                 }
                                                 else if (_lastStartTimes.TryRemove(key, out var startTime))
                                                 {
-                                                    dataMessage.KeyValues["StartTime"] = startTime;
-                                                    dataMessage.Values["EndTime"] = timestamp;
+                                                    if (!string.IsNullOrEmpty(trigger.StartTimeName))
+                                                    {
+                                                        dataMessage.KeyValues[trigger.StartTimeName] = startTime;
+                                                    }
+                                                    if (!string.IsNullOrEmpty(trigger.EndTimeName))
+                                                    {
+                                                        dataMessage.Values[trigger.EndTimeName] = timestamp;
+                                                    }
                                                     _queue.PublishAsync(dataMessage);
                                                 }
                                             }

--- a/DataAcquisition.Core/Models/DeviceConfig.cs
+++ b/DataAcquisition.Core/Models/DeviceConfig.cs
@@ -97,6 +97,22 @@ public class Trigger
     /// 数据类型
     /// </summary>
     public string DataType { get; set; }
+
+    /// <summary>
+    /// 数据操作类型
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public DataOperation Operation { get; set; } = DataOperation.Insert;
+
+    /// <summary>
+    /// 开始时间列名
+    /// </summary>
+    public string StartTimeName { get; set; }
+
+    /// <summary>
+    /// 结束时间列名
+    /// </summary>
+    public string EndTimeName { get; set; }
 }
 
 /// <summary>
@@ -113,12 +129,6 @@ public class Module
     /// 触发配置
     /// </summary>
     public Trigger Trigger { get; set; }
-
-    /// <summary>
-    /// 数据操作类型
-    /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public DataOperation Operation { get; set; } = DataOperation.Insert;
 
     /// <summary>
     /// 批量读取地址

--- a/DataAcquisition.Gateway/Configs/M01C123.json
+++ b/DataAcquisition.Gateway/Configs/M01C123.json
@@ -12,13 +12,13 @@
       "Trigger": {
         "Mode": "Always",
         "Register": null,
-        "DataType": null
+        "DataType": null,
+        "Operation": "Insert"
       },
       "BatchReadRegister": "D6000",
       "BatchReadLength": 70,
       "TableName": "m01c01_sensor",
       "BatchSize": 1,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_temp",
@@ -43,13 +43,14 @@
       "Trigger": {
         "Mode": "RisingEdge",
         "Register": "D6200",
-        "DataType": "short"
+        "DataType": "short",
+        "Operation": "Insert",
+        "StartTimeName": "start_time"
       },
       "BatchReadRegister": "D6100",
       "BatchReadLength": 200,
       "TableName": "m01c01_recipe",
       "BatchSize": 1,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_set_temp",
@@ -74,13 +75,15 @@
       "Trigger": {
         "Mode": "FallingEdge",
         "Register": "D6200",
-        "DataType": "short"
+        "DataType": "short",
+        "Operation": "Update",
+        "StartTimeName": "start_time",
+        "EndTimeName": "end_time"
       },
       "BatchReadRegister": null,
       "BatchReadLength": 0,
       "TableName": "m01c01_recipe",
       "BatchSize": 1,
-      "Operation": "Update",
       "DataPoints": null
     }
   ]

--- a/README.en.md
+++ b/README.en.md
@@ -48,11 +48,13 @@ Modules:
       Mode: Always|ValueIncrease|ValueDecrease|RisingEdge|FallingEdge # Trigger mode
       Register: string          # Trigger register address
       DataType: ushort|uint|ulong|short|int|long|float|double # Trigger register data type
+      Operation: Insert|Update  # Data operation type
+      StartTimeName: string     # [Optional] column name for start time
+      EndTimeName: string       # [Optional] column name for end time
     BatchReadRegister: string   # Start register for batch reading
     BatchReadLength: int        # Number of registers to read
     TableName: string           # Target database table
     BatchSize: int              # Number of records per batch (1 inserts one by one)
-    Operation: Insert|Update    # Data operation type
     DataPoints:
       - ColumnName: string      # Column name in the database
         Index: int              # Register index
@@ -79,9 +81,11 @@ Modules:
   - `string`, `bool` (DataPoints only)
 - **Encoding**
   - `UTF8`, `GB2312`, `GBK`, `ASCII`
-- **Module.Operation**
+- **Trigger.Operation**
   - `Insert`: insert a new record
   - `Update`: update an existing record
+- **Trigger.StartTimeName / Trigger.EndTimeName**
+  - Optional column names for start and end timestamps
 
 #### ⚖️ EvalExpression usage
 `EvalExpression` converts the raw register value before storage. The expression may reference the variable `value` representing the raw number and can use basic arithmetic. For example, `"value / 1000.0"` scales the value; leave it empty to skip conversion.
@@ -104,13 +108,14 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
       "Trigger": {
         "Mode": "Always",
         "Register": null,
-        "DataType": null
+        "DataType": null,
+        "Operation": "Insert",
+        "StartTimeName": "StartTime"
       },
       "BatchReadRegister": "D6000",
       "BatchReadLength": 70,
       "TableName": "m01c01_sensor",
       "BatchSize": 1,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_temp",
@@ -135,13 +140,13 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
       "Trigger": {
         "Mode": "RisingEdge",
         "Register": null,
-        "DataType": null
+        "DataType": null,
+        "Operation": "Insert"
       },
       "BatchReadRegister": "D6100",
       "BatchReadLength": 200,
       "TableName": "m01c02_sensor",
       "BatchSize": 10,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_set_temp",
@@ -160,9 +165,25 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
           "EvalExpression": "value / 1000.0"
         }
       ]
-    }
-  ]
-}
+      },
+      {
+        "ChamberCode": "M01C01",
+        "Trigger": {
+          "Mode": "FallingEdge",
+          "Register": null,
+          "DataType": null,
+          "Operation": "Update",
+          "StartTimeName": "StartTime",
+          "EndTimeName": "EndTime"
+        },
+        "BatchReadRegister": null,
+        "BatchReadLength": 0,
+        "TableName": "m01c01_sensor",
+        "BatchSize": 1,
+        "DataPoints": null
+      }
+    ]
+  }
 ```
 
 ## 🧩 Application setup

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Modules:                        # 采集模块配置数组
       Mode: Always|ValueIncrease|ValueDecrease|RisingEdge|FallingEdge # 触发模式
       Register: string          # 触发寄存器地址
       DataType: ushort|uint|ulong|short|int|long|float|double # 触发寄存器数据类型
+      Operation: Insert|Update  # 数据操作类型
+      StartTimeName: string     # [可选] 开始时间列名
+      EndTimeName: string       # [可选] 结束时间列名
     BatchReadRegister: string   # 批量读取寄存器地址
     BatchReadLength: int        # 批量读取长度
     TableName: string           # 数据库表名
     BatchSize: int              # 批量保存大小，1 表示逐条保存
-    Operation: Insert|Update    # 数据操作类型
     DataPoints:                 # 数据配置
       - ColumnName: string      # 数据库列名
         Index: int              # 寄存器索引
@@ -79,9 +81,11 @@ Modules:                        # 采集模块配置数组
   - `string`、`bool`（仅用于 DataPoints）。
 - **Encoding**
   - `UTF8`、`GB2312`、`GBK`、`ASCII`。
-- **Module.Operation**
+- **Trigger.Operation**
   - `Insert`：插入新记录。
   - `Update`：更新已有记录。
+- **Trigger.StartTimeName / Trigger.EndTimeName**
+  - 可选的开始时间和结束时间列名。
 
 #### ⚖️ EvalExpression 用法
 `EvalExpression` 用于在写入数据库前对寄存器读数进行转换。表达式中可使用变量 `value` 表示原始值，如 `"value / 1000.0"`。留空字符串则不进行任何转换。
@@ -104,13 +108,14 @@ Modules:                        # 采集模块配置数组
       "Trigger": {
         "Mode": "Always",
         "Register": null,
-        "DataType": null
+        "DataType": null,
+        "Operation": "Insert",
+        "StartTimeName": "StartTime"
       },
       "BatchReadRegister": "D6000",
       "BatchReadLength": 70,
       "TableName": "m01c01_sensor",
       "BatchSize": 1,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_temp",
@@ -135,13 +140,13 @@ Modules:                        # 采集模块配置数组
       "Trigger": {
         "Mode": "RisingEdge",
         "Register": null,
-        "DataType": null
+        "DataType": null,
+        "Operation": "Insert"
       },
       "BatchReadRegister": "D6100",
       "BatchReadLength": 200,
       "TableName": "m01c02_sensor",
       "BatchSize": 10,
-      "Operation": "Insert",
       "DataPoints": [
         {
           "ColumnName": "up_set_temp",
@@ -160,9 +165,25 @@ Modules:                        # 采集模块配置数组
           "EvalExpression": "value / 1000.0"
         }
       ]
-    }
-  ]
-}
+      },
+      {
+        "ChamberCode": "M01C01",
+        "Trigger": {
+          "Mode": "FallingEdge",
+          "Register": null,
+          "DataType": null,
+          "Operation": "Update",
+          "StartTimeName": "StartTime",
+          "EndTimeName": "EndTime"
+        },
+        "BatchReadRegister": null,
+        "BatchReadLength": 0,
+        "TableName": "m01c01_sensor",
+        "BatchSize": 1,
+        "DataPoints": null
+      }
+    ]
+  }
 ```
 
 ## 🧩 系统配置


### PR DESCRIPTION
## Summary
- move `Operation` into `Trigger`
- add configurable `StartTimeName` and `EndTimeName`
- update sample configs and docs for trigger-level operation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf97e2b950832ebeccd4b0c1567076