### PR TITLE
refactor: use built-in type aliases

### DIFF
--- a/DataAcquisition.Core/Communication/ICommunication.cs
+++ b/DataAcquisition.Core/Communication/ICommunication.cs
@@ -23,32 +23,41 @@ public interface ICommunication
     /// 写寄存器。
     /// </summary>
     /// <param name="address">寄存器地址</param>
-    /// <param name="value">写入值，支持多种数据类型</param>
-    Task<CommunicationWriteResult> WriteAsync(string address, object value);
+    /// <param name="value">写入值</param>
+    Task<CommunicationWriteResult> WriteUShortAsync(string address, ushort value);
+    Task<CommunicationWriteResult> WriteUIntAsync(string address, uint value);
+    Task<CommunicationWriteResult> WriteULongAsync(string address, ulong value);
+    Task<CommunicationWriteResult> WriteShortAsync(string address, short value);
+    Task<CommunicationWriteResult> WriteIntAsync(string address, int value);
+    Task<CommunicationWriteResult> WriteLongAsync(string address, long value);
+    Task<CommunicationWriteResult> WriteFloatAsync(string address, float value);
+    Task<CommunicationWriteResult> WriteDoubleAsync(string address, double value);
+    Task<CommunicationWriteResult> WriteStringAsync(string address, string value);
+    Task<CommunicationWriteResult> WriteBoolAsync(string address, bool value);
 
     /// <summary>
     /// 批量读取原始数据。
     /// </summary>
     /// <param name="address">起始地址</param>
     /// <param name="length">长度</param>
-    CommunicationReadResult Read(string address, ushort length);
+    Task<CommunicationReadResult> ReadAsync(string address, ushort length);
 
-    ushort ReadUInt16(string address);
-    uint ReadUInt32(string address);
-    ulong ReadUInt64(string address);
-    short ReadInt16(string address);
-    int ReadInt32(string address);
-    long ReadInt64(string address);
-    float ReadFloat(string address);
-    double ReadDouble(string address);
+    Task<ushort> ReadUShortAsync(string address);
+    Task<uint> ReadUIntAsync(string address);
+    Task<ulong> ReadULongAsync(string address);
+    Task<short> ReadShortAsync(string address);
+    Task<int> ReadIntAsync(string address);
+    Task<long> ReadLongAsync(string address);
+    Task<float> ReadFloatAsync(string address);
+    Task<double> ReadDoubleAsync(string address);
 
-    ushort TransUInt16(byte[] buffer, int index);
-    uint TransUInt32(byte[] buffer, int index);
-    ulong TransUInt64(byte[] buffer, int index);
-    short TransInt16(byte[] buffer, int index);
-    int TransInt32(byte[] buffer, int index);
-    long TransInt64(byte[] buffer, int index);
-    float TransSingle(byte[] buffer, int index);
+    ushort TransUShort(byte[] buffer, int index);
+    uint TransUInt(byte[] buffer, int index);
+    ulong TransULong(byte[] buffer, int index);
+    short TransShort(byte[] buffer, int index);
+    int TransInt(byte[] buffer, int index);
+    long TransLong(byte[] buffer, int index);
+    float TransFloat(byte[] buffer, int index);
     double TransDouble(byte[] buffer, int index);
     string TransString(byte[] buffer, int index, int length, Encoding encoding);
     bool TransBool(byte[] buffer, int index);

--- a/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
+++ b/DataAcquisition.Gateway/Infrastructure/Communication/Communication.cs
@@ -1,5 +1,6 @@
 using System.Net.NetworkInformation;
 using System.Text;
+using System.Threading.Tasks;
 using DataAcquisition.Core.Communication;
 using DataAcquisition.Core.Models;
 using HslCommunication.Core.Device;
@@ -26,56 +27,69 @@ public class Communication : ICommunication
     public Task ConnectCloseAsync() => _device.ConnectCloseAsync();
 
     public IPStatus IpAddressPing() => _device.IpAddressPing();
-
-    public async Task<CommunicationWriteResult> WriteAsync(string address, object value)
+    public async Task<CommunicationWriteResult> WriteUShortAsync(string address, ushort value)
     {
-        HslCommunication.OperateResult res;
-        switch (value)
-        {
-            case ushort v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case uint v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case ulong v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case short v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case int v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case long v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case float v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case double v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case string v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            case bool v:
-                res = await _device.WriteAsync(address, v);
-                break;
-            default:
-                return new CommunicationWriteResult
-                {
-                    IsSuccess = false,
-                    Message = $"Unsupported value type: {value?.GetType()}"
-                };
-        }
-
+        var res = await _device.WriteAsync(address, value);
         return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
     }
 
-    public CommunicationReadResult Read(string address, ushort length)
+    public async Task<CommunicationWriteResult> WriteUIntAsync(string address, uint value)
     {
-        var res = _device.Read(address, length);
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteULongAsync(string address, ulong value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteShortAsync(string address, short value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteIntAsync(string address, int value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteLongAsync(string address, long value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteFloatAsync(string address, float value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteDoubleAsync(string address, double value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteStringAsync(string address, string value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationWriteResult> WriteBoolAsync(string address, bool value)
+    {
+        var res = await _device.WriteAsync(address, value);
+        return new CommunicationWriteResult { IsSuccess = res.IsSuccess, Message = res.Message };
+    }
+
+    public async Task<CommunicationReadResult> ReadAsync(string address, ushort length)
+    {
+        var res = await _device.ReadAsync(address, length);
         return new CommunicationReadResult
         {
             IsSuccess = res.IsSuccess,
@@ -84,61 +98,61 @@ public class Communication : ICommunication
         };
     }
 
-    public ushort ReadUInt16(string address)
+    public async Task<ushort> ReadUShortAsync(string address)
     {
-        var res = _device.ReadUInt16(address, 1);
+        var res = await _device.ReadUInt16Async(address, 1);
         return res.Content[0];
     }
 
-    public uint ReadUInt32(string address)
+    public async Task<uint> ReadUIntAsync(string address)
     {
-        var res = _device.ReadUInt32(address, 1);
+        var res = await _device.ReadUInt32Async(address, 1);
         return res.Content[0];
     }
 
-    public ulong ReadUInt64(string address)
+    public async Task<ulong> ReadULongAsync(string address)
     {
-        var res = _device.ReadUInt64(address, 1);
+        var res = await _device.ReadUInt64Async(address, 1);
         return res.Content[0];
     }
 
-    public short ReadInt16(string address)
+    public async Task<short> ReadShortAsync(string address)
     {
-        var res = _device.ReadInt16(address, 1);
+        var res = await _device.ReadInt16Async(address, 1);
         return res.Content[0];
     }
 
-    public int ReadInt32(string address)
+    public async Task<int> ReadIntAsync(string address)
     {
-        var res = _device.ReadInt32(address, 1);
+        var res = await _device.ReadInt32Async(address, 1);
         return res.Content[0];
     }
 
-    public long ReadInt64(string address)
+    public async Task<long> ReadLongAsync(string address)
     {
-        var res = _device.ReadInt64(address, 1);
+        var res = await _device.ReadInt64Async(address, 1);
         return res.Content[0];
     }
 
-    public float ReadFloat(string address)
+    public async Task<float> ReadFloatAsync(string address)
     {
-        var res = _device.ReadFloat(address, 1);
+        var res = await _device.ReadFloatAsync(address, 1);
         return res.Content[0];
     }
 
-    public double ReadDouble(string address)
+    public async Task<double> ReadDoubleAsync(string address)
     {
-        var res = _device.ReadDouble(address, 1);
+        var res = await _device.ReadDoubleAsync(address, 1);
         return res.Content[0];
     }
 
-    public ushort TransUInt16(byte[] buffer, int index) => _device.ByteTransform.TransUInt16(buffer, index);
-    public uint TransUInt32(byte[] buffer, int index) => _device.ByteTransform.TransUInt32(buffer, index);
-    public ulong TransUInt64(byte[] buffer, int index) => _device.ByteTransform.TransUInt64(buffer, index);
-    public short TransInt16(byte[] buffer, int index) => _device.ByteTransform.TransInt16(buffer, index);
-    public int TransInt32(byte[] buffer, int index) => _device.ByteTransform.TransInt32(buffer, index);
-    public long TransInt64(byte[] buffer, int index) => _device.ByteTransform.TransInt64(buffer, index);
-    public float TransSingle(byte[] buffer, int index) => _device.ByteTransform.TransSingle(buffer, index);
+    public ushort TransUShort(byte[] buffer, int index) => _device.ByteTransform.TransUInt16(buffer, index);
+    public uint TransUInt(byte[] buffer, int index) => _device.ByteTransform.TransUInt32(buffer, index);
+    public ulong TransULong(byte[] buffer, int index) => _device.ByteTransform.TransUInt64(buffer, index);
+    public short TransShort(byte[] buffer, int index) => _device.ByteTransform.TransInt16(buffer, index);
+    public int TransInt(byte[] buffer, int index) => _device.ByteTransform.TransInt32(buffer, index);
+    public long TransLong(byte[] buffer, int index) => _device.ByteTransform.TransInt64(buffer, index);
+    public float TransFloat(byte[] buffer, int index) => _device.ByteTransform.TransSingle(buffer, index);
     public double TransDouble(byte[] buffer, int index) => _device.ByteTransform.TransDouble(buffer, index);
     public string TransString(byte[] buffer, int index, int length, Encoding encoding) => _device.ByteTransform.TransString(buffer, index, length, encoding);
     public bool TransBool(byte[] buffer, int index) => _device.ByteTransform.TransBool(buffer, index);


### PR DESCRIPTION
## Summary
- convert communication read methods to async to align with alias-based naming
- adapt data acquisition service to await new Read*Async helpers using SemaphoreSlim for concurrency
- implement async reads in gateway communication adapter

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbd251c14832e94f7e2b4a732b31a