### PR TITLE
Replace StartTimeName and EndTimeName with TimeColumnName

### DIFF
--- a/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
+++ b/DataAcquisition.Core/DataAcquisitions/DataAcquisitionService.cs
@@ -134,22 +134,19 @@ namespace DataAcquisition.Core.DataAcquisitions
                                                         var value = TransValue(client, buffer, dataPoint.Index, dataPoint.StringByteLength, dataPoint.DataType, dataPoint.Encoding);
                                                         dataMessage.Values[dataPoint.ColumnName] = value;
                                                     }
-                                                    if (!string.IsNullOrEmpty(trigger.StartTimeName))
+                                                    if (!string.IsNullOrEmpty(trigger.TimeColumnName))
                                                     {
-                                                        dataMessage.Values[trigger.StartTimeName] = timestamp;
+                                                        dataMessage.Values[trigger.TimeColumnName] = timestamp;
                                                         _lastStartTimes[key] = timestamp;
                                                     }
                                                     _queue.PublishAsync(dataMessage);
                                                 }
                                                 else if (_lastStartTimes.TryRemove(key, out var startTime))
                                                 {
-                                                    if (!string.IsNullOrEmpty(trigger.StartTimeName))
+                                                    if (!string.IsNullOrEmpty(trigger.TimeColumnName))
                                                     {
-                                                        dataMessage.KeyValues[trigger.StartTimeName] = startTime;
-                                                    }
-                                                    if (!string.IsNullOrEmpty(trigger.EndTimeName))
-                                                    {
-                                                        dataMessage.Values[trigger.EndTimeName] = timestamp;
+                                                        dataMessage.KeyValues[trigger.TimeColumnName] = startTime;
+                                                        dataMessage.Values[trigger.TimeColumnName] = timestamp;
                                                     }
                                                     _queue.PublishAsync(dataMessage);
                                                 }

--- a/DataAcquisition.Core/Models/DeviceConfig.cs
+++ b/DataAcquisition.Core/Models/DeviceConfig.cs
@@ -105,14 +105,9 @@ public class Trigger
     public DataOperation Operation { get; set; } = DataOperation.Insert;
 
     /// <summary>
-    /// 开始时间列名
+    /// 时间列名
     /// </summary>
-    public string StartTimeName { get; set; }
-
-    /// <summary>
-    /// 结束时间列名
-    /// </summary>
-    public string EndTimeName { get; set; }
+    public string TimeColumnName { get; set; }
 }
 
 /// <summary>

--- a/DataAcquisition.Gateway/Configs/M01C123.json
+++ b/DataAcquisition.Gateway/Configs/M01C123.json
@@ -45,7 +45,7 @@
         "Register": "D6200",
         "DataType": "short",
         "Operation": "Insert",
-        "StartTimeName": "start_time"
+        "TimeColumnName": "start_time"
       },
       "BatchReadRegister": "D6100",
       "BatchReadLength": 200,
@@ -77,8 +77,7 @@
         "Register": "D6200",
         "DataType": "short",
         "Operation": "Update",
-        "StartTimeName": "start_time",
-        "EndTimeName": "end_time"
+        "TimeColumnName": "start_time"
       },
       "BatchReadRegister": null,
       "BatchReadLength": 0,

--- a/README.en.md
+++ b/README.en.md
@@ -49,8 +49,7 @@ Modules:
       Register: string          # Trigger register address
       DataType: ushort|uint|ulong|short|int|long|float|double # Trigger register data type
       Operation: Insert|Update  # Data operation type
-      StartTimeName: string     # [Optional] column name for start time
-      EndTimeName: string       # [Optional] column name for end time
+      TimeColumnName: string    # [Optional] column name for timestamp
     BatchReadRegister: string   # Start register for batch reading
     BatchReadLength: int        # Number of registers to read
     TableName: string           # Target database table
@@ -84,8 +83,8 @@ Modules:
 - **Trigger.Operation**
   - `Insert`: insert a new record
   - `Update`: update an existing record
-- **Trigger.StartTimeName / Trigger.EndTimeName**
-  - Optional column names for start and end timestamps
+- **Trigger.TimeColumnName**
+  - Optional column name for timestamps
 
 #### ⚖️ EvalExpression usage
 `EvalExpression` converts the raw register value before storage. The expression may reference the variable `value` representing the raw number and can use basic arithmetic. For example, `"value / 1000.0"` scales the value; leave it empty to skip conversion.
@@ -110,7 +109,7 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
         "Register": null,
         "DataType": null,
         "Operation": "Insert",
-        "StartTimeName": "StartTime"
+        "TimeColumnName": "StartTime"
       },
       "BatchReadRegister": "D6000",
       "BatchReadLength": 70,
@@ -173,8 +172,7 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
           "Register": null,
           "DataType": null,
           "Operation": "Update",
-          "StartTimeName": "StartTime",
-          "EndTimeName": "EndTime"
+          "TimeColumnName": "StartTime"
         },
         "BatchReadRegister": null,
         "BatchReadLength": 0,

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Modules:                        # 采集模块配置数组
       Register: string          # 触发寄存器地址
       DataType: ushort|uint|ulong|short|int|long|float|double # 触发寄存器数据类型
       Operation: Insert|Update  # 数据操作类型
-      StartTimeName: string     # [可选] 开始时间列名
-      EndTimeName: string       # [可选] 结束时间列名
+      TimeColumnName: string    # [可选] 时间列名
     BatchReadRegister: string   # 批量读取寄存器地址
     BatchReadLength: int        # 批量读取长度
     TableName: string           # 数据库表名
@@ -84,8 +83,8 @@ Modules:                        # 采集模块配置数组
 - **Trigger.Operation**
   - `Insert`：插入新记录。
   - `Update`：更新已有记录。
-- **Trigger.StartTimeName / Trigger.EndTimeName**
-  - 可选的开始时间和结束时间列名。
+- **Trigger.TimeColumnName**
+  - 可选的时间列名。
 
 #### ⚖️ EvalExpression 用法
 `EvalExpression` 用于在写入数据库前对寄存器读数进行转换。表达式中可使用变量 `value` 表示原始值，如 `"value / 1000.0"`。留空字符串则不进行任何转换。
@@ -110,7 +109,7 @@ Modules:                        # 采集模块配置数组
         "Register": null,
         "DataType": null,
         "Operation": "Insert",
-        "StartTimeName": "StartTime"
+        "TimeColumnName": "StartTime"
       },
       "BatchReadRegister": "D6000",
       "BatchReadLength": 70,
@@ -173,8 +172,7 @@ Modules:                        # 采集模块配置数组
           "Register": null,
           "DataType": null,
           "Operation": "Update",
-          "StartTimeName": "StartTime",
-          "EndTimeName": "EndTime"
+          "TimeColumnName": "StartTime"
         },
         "BatchReadRegister": null,
         "BatchReadLength": 0,


### PR DESCRIPTION
## Summary
- unify StartTimeName and EndTimeName into a single `TimeColumnName`
- update data acquisition logic to use `TimeColumnName`
- revise sample config and documentation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc3ab1030832e96fda2ad5bdc23cc