### PR TITLE
docs: clarify gateway extension points

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,12 @@
 ## 📘 Overview
 The PLC Data Acquisition System collects real-time operational data from programmable logic controllers and forwards the results to message queues and databases, supporting equipment monitoring, performance analysis, and fault diagnosis.
 
+## 🔧 Development Guide
+- The core workflow is to implement the interfaces under the `Infrastructure` folder of the `DataAcquisition.Gateway` project.
+- The default implementation uses [HslCommunication](https://github.com/dathlin/HslCommunication) for Modbus communication.
+- You can replace it with any other communication library to support different PLCs or protocols—there is no restriction to Mitsubishi or Inovance devices.
+- Storage providers are also pluggable, allowing custom data sinks beyond the built-in examples.
+
 ## ✨ Key Features
 - Efficient communication using the Modbus TCP protocol.
 - Message queues (RabbitMQ, Kafka, or a local queue) handle high-throughput acquisition results.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 ## 📘 概述
 PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据，并将结果传递至消息队列和数据库，以支持工业设备监控、性能分析与故障诊断。
 
+## 🔧 开发说明
+- 数据采集的核心是在 `DataAcquisition.Gateway` 项目下的 `Infrastructure` 目录中实现各个接口。
+- 默认实现使用 [HslCommunication](https://github.com/dathlin/HslCommunication) 库进行 Modbus 通讯。
+- 使用者可根据自身需求替换为任意通讯库，不局限于三菱、汇川等特定 PLC。
+- 数据存储模块同样可扩展为自定义类型，不限制于仓库中的默认实现。
+
 ## ✨ 核心功能
 - 高效通讯：基于 Modbus TCP 协议实现稳定的数据传输。
 - 消息队列：可将采集结果写入 RabbitMQ、Kafka 或本地队列以处理高并发。


### PR DESCRIPTION
## Summary
- document how to extend data acquisition through `DataAcquisition.Gateway` infrastructure
- note that default Modbus implementation uses HslCommunication but is replaceable

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c02c6c4900832eb0a606a51de3133e