### PR TITLE
docs: reorganize README and refine comments

### DIFF
--- a/DataAcquisition.Core/Models/DeviceConfig.cs
+++ b/DataAcquisition.Core/Models/DeviceConfig.cs
@@ -19,7 +19,7 @@ public class DeviceConfig
     public string Code { get; set; }
 
     /// <summary>
-    /// IP地址
+    /// IP 地址
     /// </summary>
     public string Host { get; set; }
 
@@ -64,15 +64,15 @@ public enum TriggerMode
     /// </summary>
     ValueIncrease,
     /// <summary>
-    /// 数值减少触发
+    /// 数值减少时触发
     /// </summary>
     ValueDecrease,
     /// <summary>
-    /// 上升沿触发(表示从0变成1时采集)
+    /// 上升沿触发（寄存器从 0 变为 1 时采集）
     /// </summary>
     RisingEdge,
     /// <summary>
-    /// 下降沿触发(表示从1变成0时采集)
+    /// 下降沿触发（寄存器从 1 变为 0 时采集）
     /// </summary>
     FallingEdge
 }
@@ -171,17 +171,17 @@ public class DataPoint
     public int Index { get; set; }
 
     /// <summary>
-    /// 字符串 byte 数组长度
+    /// 字符串的字节长度
     /// </summary>
     public int StringByteLength { get; set; }
 
     /// <summary>
-    /// 仅用于字符串,字符串编码格式
+    /// 字符串编码，仅在数据类型为字符串时使用
     /// </summary>
     public string Encoding { get; set; }
 
     /// <summary>
-    /// 数据表达式计算
+    /// 数值转换表达式
     /// </summary>
     public string EvalExpression { get; set; }
 }

--- a/DataAcquisition.Gateway/DataAcquisitionHostedService.cs
+++ b/DataAcquisition.Gateway/DataAcquisitionHostedService.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace DataAcquisition.Gateway;
 
+/// <summary>
+/// 后台服务，用于管理数据采集任务的生命周期。
+/// </summary>
 public class DataAcquisitionHostedService : BackgroundService
 {
     private readonly IDataAcquisitionService _dataAcquisitionService;
@@ -14,20 +17,20 @@ public class DataAcquisitionHostedService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // 启动采集任务
+        // Start data acquisition tasks.
         await _dataAcquisitionService.StartCollectionTasks();
 
-        // 等待停止信号
+        // Wait for a cancellation signal.
         try
         {
             await Task.Delay(Timeout.Infinite, stoppingToken);
         }
         catch (OperationCanceledException)
         {
-            // 服务停止时会触发取消
+            // Triggered when the service stops.
         }
 
-        // 收尾：停止采集任务
+        // Stop data acquisition tasks.
         await _dataAcquisitionService.StopCollectionTasks();
     }
 }

--- a/DataAcquisition.Gateway/Infrastructure/DeviceConfigs/DeviceConfigService.cs
+++ b/DataAcquisition.Gateway/Infrastructure/DeviceConfigs/DeviceConfigService.cs
@@ -3,6 +3,9 @@ using DataAcquisition.Core.Models;
 
 namespace DataAcquisition.Core.DeviceConfigs;
 
+/// <summary>
+/// 提供加载设备配置文件的服务。
+/// </summary>
 public class DeviceConfigService : IDeviceConfigService
 {
     public async Task<List<DeviceConfig>> GetConfigs()
@@ -34,14 +37,14 @@ public class DeviceConfigService : IDeviceConfigService
     {
         var results = new List<T>();
 
-        // 获取所有 JSON 文件
+        // Retrieve all JSON files.
         var jsonFiles = Directory.GetFiles(directoryPath, "*.json");
 
         foreach (var filePath in jsonFiles)
         {
             try
             {
-                // 加载并反序列化 JSON 文件
+                // Load and deserialize each JSON file.
                 var config = await LoadConfigAsync<T>(filePath);
                 results.Add(config);
             }

--- a/DataAcquisition.Gateway/QueueHostedService.cs
+++ b/DataAcquisition.Gateway/QueueHostedService.cs
@@ -1,14 +1,22 @@
-﻿public class QueueHostedService : BackgroundService
+using DataAcquisition.Core.Queues;
+using Microsoft.Extensions.Hosting;
+
+namespace DataAcquisition.Gateway;
+
+/// <summary>
+/// 后台服务，负责订阅并处理队列消息。
+/// </summary>
+public class QueueHostedService : BackgroundService
 {
     private readonly IQueue _queue;
     public QueueHostedService(IQueue queue) => _queue = queue;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        =>await _queue.SubscribeAsync(stoppingToken);
+        => await _queue.SubscribeAsync(stoppingToken);
 
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
-        await _queue.DisposeAsync();            // 完成写端
-        await base.StopAsync(cancellationToken); // 等待 ExecuteAsync 正常结束
+        await _queue.DisposeAsync();            // Close the write side.
+        await base.StopAsync(cancellationToken); // Ensure ExecuteAsync completes.
     }
 }

--- a/README.en.md
+++ b/README.en.md
@@ -3,18 +3,27 @@
 [![Stars](https://img.shields.io/github/stars/liuweichaox/DataAcquisition?style=social)](https://github.com/liuweichaox/DataAcquisition/stargazers)
 [![Forks](https://img.shields.io/github/forks/liuweichaox/DataAcquisition?style=social)](https://github.com/liuweichaox/DataAcquisition/network/members)
 [![License](https://img.shields.io/github/license/liuweichaox/DataAcquisition.svg)](LICENSE)
-[![.NET](https://img.shields.io/badge/.NET-Standard%202.0%20%7C%202.1-512BD4?logo=dotnet)](#)
+[![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet)](#)
 
 [中文](README.md) | **English**
 
 ## 📘 Overview
 The PLC Data Acquisition System collects real-time operational data from programmable logic controllers and forwards the results to message queues and databases, supporting equipment monitoring, performance analysis, and fault diagnosis.
 
-## 🔧 Development Guide
-- The core workflow is to implement the interfaces under the `Infrastructure` folder of the `DataAcquisition.Gateway` project.
-- The default implementation uses [HslCommunication](https://github.com/dathlin/HslCommunication) for Modbus communication.
-- You can replace it with any other communication library to support different PLCs or protocols—there is no restriction to Mitsubishi or Inovance devices.
-- Storage providers are also pluggable, allowing custom data sinks beyond the built-in examples.
+## 🧩 System configuration
+Register the `IDataAcquisition` instance in `Program.cs` to manage acquisition tasks.
+
+```csharp
+builder.Services.AddSingleton<IMessage, Message>();
+builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
+builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
+builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
+builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
+builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
+
+builder.Services.AddHostedService<DataAcquisitionHostedService>();
+```
 
 ## ✨ Key Features
 - Efficient communication using the Modbus TCP protocol.
@@ -25,7 +34,13 @@ The PLC Data Acquisition System collects real-time operational data from program
 - Disconnection and timeout retries maintain stability.
 - Acquisition frequency is configurable down to milliseconds.
 - Configuration files define table structures, column names, and sampling frequency.
-- Compatible with .NET Standard 2.0/2.1 and runs on Windows, Linux, and macOS.
+- Built on .NET 8.0 and runs on Windows, Linux, and macOS.
+
+## 🔧 Development Guide
+- The core workflow is to implement the interfaces under the `Infrastructure` folder of the `DataAcquisition.Gateway` project.
+- The default implementation uses [HslCommunication](https://github.com/dathlin/HslCommunication) for Modbus communication.
+- You can replace it with any other communication library to support different PLCs or protocols—there is no restriction to Mitsubishi or Inovance devices.
+- Storage providers are also pluggable, allowing custom data sinks beyond the built-in examples.
 
 ## 🛠️ Installation
 ### 📥 Clone the repository
@@ -192,20 +207,27 @@ The file `DataAcquisition.Gateway/Configs/M01C123.json` illustrates a typical co
 }
 ```
 
-## 🧩 Application setup
-Register the `IDataAcquisition` instance in `Startup.cs` to manage acquisition tasks.
+## 🏃 Run
+Make sure the .NET 8.0 SDK is installed.
 
-```csharp
-builder.Services.AddSingleton<IMessage, Message>();
-builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
-builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
-builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
-builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
-builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
-builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
-
-builder.Services.AddHostedService<DataAcquisitionHostedService>();
+```bash
+dotnet restore
+dotnet build
+dotnet run --project DataAcquisition.Gateway
 ```
+
+The service listens on http://localhost:8000 by default.
+
+## 🚀 Deployment
+Use `dotnet publish` to generate self-contained executables for different platforms:
+
+```bash
+dotnet publish DataAcquisition.Gateway -c Release -r win-x64 --self-contained true
+dotnet publish DataAcquisition.Gateway -c Release -r linux-x64 --self-contained true
+dotnet publish DataAcquisition.Gateway -c Release -r osx-x64 --self-contained true
+```
+
+Copy the contents of the `publish` folder to the target environment and run the platform-specific executable.
 
 ## 🔌 API
 ### 📡 Get PLC connection status

--- a/README.md
+++ b/README.md
@@ -3,18 +3,27 @@
 [![Stars](https://img.shields.io/github/stars/liuweichaox/DataAcquisition?style=social)](https://github.com/liuweichaox/DataAcquisition/stargazers)
 [![Forks](https://img.shields.io/github/forks/liuweichaox/DataAcquisition?style=social)](https://github.com/liuweichaox/DataAcquisition/network/members)
 [![License](https://img.shields.io/github/license/liuweichaox/DataAcquisition.svg)](LICENSE)
-[![.NET](https://img.shields.io/badge/.NET-Standard%202.0%20%7C%202.1-512BD4?logo=dotnet)](#)
+[![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet)](#)
 
 **中文** | [English](README.en.md)
 
 ## 📘 概述
 PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据，并将结果传递至消息队列和数据库，以支持工业设备监控、性能分析与故障诊断。
 
-## 🔧 开发说明
-- 数据采集的核心是在 `DataAcquisition.Gateway` 项目下的 `Infrastructure` 目录中实现各个接口。
-- 默认实现使用 [HslCommunication](https://github.com/dathlin/HslCommunication) 库进行 Modbus 通讯。
-- 使用者可根据自身需求替换为任意通讯库，不局限于三菱、汇川等特定 PLC。
-- 数据存储模块同样可扩展为自定义类型，不限制于仓库中的默认实现。
+## 🧩 系统配置
+在 `Program.cs` 中注册 `IDataAcquisition` 实例以管理采集任务。
+
+```csharp
+builder.Services.AddSingleton<IMessage, Message>();
+builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
+builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
+builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
+builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
+builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
+
+builder.Services.AddHostedService<DataAcquisitionHostedService>();
+```
 
 ## ✨ 核心功能
 - 高效通讯：基于 Modbus TCP 协议实现稳定的数据传输。
@@ -25,7 +34,13 @@ PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据�
 - 错误处理：提供断线重连和超时重试机制。
 - 频率控制：采集频率可配置，最低支持毫秒级。
 - 动态配置：通过配置文件定义表结构、列名和频率。
-- 多平台支持：兼容 .NET Standard 2.0 与 2.1，运行于 Windows、Linux 和 macOS。
+- 多平台支持：基于 .NET 8.0，运行于 Windows、Linux 和 macOS。
+
+## 🔧 开发说明
+- 数据采集的核心是在 `DataAcquisition.Gateway` 项目下的 `Infrastructure` 目录中实现各个接口。
+- 默认实现使用 [HslCommunication](https://github.com/dathlin/HslCommunication) 库进行 Modbus 通讯。
+- 使用者可根据自身需求替换为任意通讯库，不局限于三菱、汇川等特定 PLC。
+- 数据存储模块同样可扩展为自定义类型，不限制于仓库中的默认实现。
 
 ## 🛠️ 安装
 ### 📥 克隆仓库
@@ -191,20 +206,27 @@ Modules:                        # 采集模块配置数组
 }
 ```
 
-## 🧩 系统配置
-在 `Startup.cs` 中注册 `IDataAcquisition` 实例以管理采集任务。
+## 🏃 运行
+确保已安装 .NET 8.0 SDK。
 
-```csharp
-builder.Services.AddSingleton<IMessage, Message>();
-builder.Services.AddSingleton<ICommunicationFactory, CommunicationFactory>();
-builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
-builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
-builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
-builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
-builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
-
-builder.Services.AddHostedService<DataAcquisitionHostedService>();
+```bash
+dotnet restore
+dotnet build
+dotnet run --project DataAcquisition.Gateway
 ```
+
+服务启动后默认监听 http://localhost:8000 端口。
+
+## 🚀 部署
+使用 `dotnet publish` 生成跨平台的自包含可执行文件：
+
+```bash
+dotnet publish DataAcquisition.Gateway -c Release -r win-x64 --self-contained true
+dotnet publish DataAcquisition.Gateway -c Release -r linux-x64 --self-contained true
+dotnet publish DataAcquisition.Gateway -c Release -r osx-x64 --self-contained true
+```
+
+将生成的 `publish` 目录内容复制到目标环境并运行对应平台的可执行文件。
 
 ## 🔌 API
 ### 📡 获取 PLC 连接状态


### PR DESCRIPTION
## Summary
- highlight .NET 8.0 cross-platform support and default port 8000 in both READMEs
- add run and deployment instructions for building and publishing the gateway
- formalize service and configuration comments for clearer lifecycle and pipeline guidance

## Testing
- `dotnet build DataAcquisition.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c034fa7d74832e9207b8977fd10591