### PR TITLE
refactor: centralize abstractions and rename interfaces

### DIFF
--- a/DataAcquisition.Application/Abstractions/IDataAcquisitionService.cs
+++ b/DataAcquisition.Application/Abstractions/IDataAcquisitionService.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DataAcquisition.Domain.Clients;
 
-namespace DataAcquisition.Application.DataAcquisitions;
+namespace DataAcquisition.Application.Abstractions;
 
 /// <summary>
 /// Defines the contract for data acquisition operations.

--- a/DataAcquisition.Application/Abstractions/IDataProcessingService.cs
+++ b/DataAcquisition.Application/Abstractions/IDataProcessingService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace DataAcquisition.Application.DataProcessing;
+namespace DataAcquisition.Application.Abstractions;
 
 public interface IDataProcessingService
 {

--- a/DataAcquisition.Application/Abstractions/IDataStorageService.cs
+++ b/DataAcquisition.Application/Abstractions/IDataStorageService.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace DataAcquisition.Application.DataStorages;
+namespace DataAcquisition.Application.Abstractions;
 
 /// <summary>
 /// 数据存储服务
 /// </summary>
-public interface IDataStorage
+public interface IDataStorageService
 {
     /// <summary>
     /// 保存

--- a/DataAcquisition.Application/Abstractions/IDeviceConfigService.cs
+++ b/DataAcquisition.Application/Abstractions/IDeviceConfigService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace DataAcquisition.Application.DeviceConfigs;
+namespace DataAcquisition.Application.Abstractions;
 
 /// <summary>
 /// 采集配置服务接口

--- a/DataAcquisition.Application/Abstractions/IOperationalEventsService.cs
+++ b/DataAcquisition.Application/Abstractions/IOperationalEventsService.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace DataAcquisition.Application.OperationalEvents;
+namespace DataAcquisition.Application.Abstractions;
 
-public interface IOperationalEvents
+public interface IOperationalEventsService
 {
     Task InfoAsync(string deviceCode, string message, object? data = null, CancellationToken ct = default);
     Task WarnAsync(string deviceCode, string message, object? data = null, CancellationToken ct = default);

--- a/DataAcquisition.Application/Abstractions/IPlcClientFactory.cs
+++ b/DataAcquisition.Application/Abstractions/IPlcClientFactory.cs
@@ -1,6 +1,6 @@
 using DataAcquisition.Domain.Models;
 
-namespace DataAcquisition.Application.Clients;
+namespace DataAcquisition.Application.Abstractions;
 
 /// <summary>
 /// 通讯客户端工厂
@@ -12,5 +12,5 @@ public interface IPlcClientFactory
     /// </summary>
     /// <param name="config">设备配置</param>
     /// <returns>通讯客户端</returns>
-    IPlcClient Create(DeviceConfig config);
+    IPlcClientService Create(DeviceConfig config);
 }

--- a/DataAcquisition.Application/Abstractions/IPlcClientService.cs
+++ b/DataAcquisition.Application/Abstractions/IPlcClientService.cs
@@ -3,12 +3,12 @@ using System.Text;
 using System.Threading.Tasks;
 using DataAcquisition.Domain.Clients;
 
-namespace DataAcquisition.Application.Clients;
+namespace DataAcquisition.Application.Abstractions;
 
 /// <summary>
 /// 通讯客户端通用接口，封装具体协议实现。
 /// </summary>
-public interface IPlcClient
+public interface IPlcClientService
 {
     /// <summary>
     /// 关闭连接。

--- a/DataAcquisition.Application/Abstractions/IQueueService.cs
+++ b/DataAcquisition.Application/Abstractions/IQueueService.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace DataAcquisition.Application.Queues;
+namespace DataAcquisition.Application.Abstractions;
 
-public interface IQueue : IAsyncDisposable
+public interface IQueueService : IAsyncDisposable
 {
     Task PublishAsync(DataMessage dataMessage);
 

--- a/DataAcquisition.Gateway/Controllers/DataAcquisitionController.cs
+++ b/DataAcquisition.Gateway/Controllers/DataAcquisitionController.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using DataAcquisition.Application.DataAcquisitions;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Clients;
 using DataAcquisition.Gateway.Models;
 using Microsoft.AspNetCore.Mvc;

--- a/DataAcquisition.Gateway/DataAcquisitionHostedService.cs
+++ b/DataAcquisition.Gateway/DataAcquisitionHostedService.cs
@@ -1,4 +1,4 @@
-﻿using DataAcquisition.Application.DataAcquisitions;
+﻿using DataAcquisition.Application.Abstractions;
 using Microsoft.Extensions.Hosting;
 
 namespace DataAcquisition.Gateway;

--- a/DataAcquisition.Gateway/Program.cs
+++ b/DataAcquisition.Gateway/Program.cs
@@ -1,12 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using DataAcquisition.Application.Clients;
-using DataAcquisition.Application.DataAcquisitions;
-using DataAcquisition.Application.DataProcessing;
-using DataAcquisition.Application.DataStorages;
-using DataAcquisition.Application.DeviceConfigs;
-using DataAcquisition.Application.OperationalEvents;
-using DataAcquisition.Application.Queues;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Gateway;
 using DataAcquisition.Gateway.Hubs;
 using DataAcquisition.Infrastructure.Clients;
@@ -23,10 +17,10 @@ builder.WebHost.UseUrls("http://localhost:8000");
 builder.Services.AddMemoryCache();
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
-builder.Services.AddSingleton<IOperationalEvents, OperationalEvents>();
+builder.Services.AddSingleton<IOperationalEventsService, OperationalEvents>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
-builder.Services.AddSingleton<IQueue, LocalQueue>();
-builder.Services.AddSingleton<IDataStorage, MySqlDataStorage>();
+builder.Services.AddSingleton<IQueueService, LocalQueue>();
+builder.Services.AddSingleton<IDataStorageService, MySqlDataStorage>();
 builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
 builder.Services.AddSingleton<IDataAcquisitionService, DataAcquisitionService>();
 

--- a/DataAcquisition.Gateway/QueueHostedService.cs
+++ b/DataAcquisition.Gateway/QueueHostedService.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using DataAcquisition.Application.Queues;
+using DataAcquisition.Application.Abstractions;
 using Microsoft.Extensions.Hosting;
 
 namespace DataAcquisition.Gateway;
@@ -10,8 +10,8 @@ namespace DataAcquisition.Gateway;
 /// </summary>
 public class QueueHostedService : BackgroundService
 {
-    private readonly IQueue _queue;
-    public QueueHostedService(IQueue queue) => _queue = queue;
+    private readonly IQueueService _queue;
+    public QueueHostedService(IQueueService queue) => _queue = queue;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         => await _queue.SubscribeAsync(stoppingToken);

--- a/DataAcquisition.Infrastructure/Clients/PlcClient.cs
+++ b/DataAcquisition.Infrastructure/Clients/PlcClient.cs
@@ -1,7 +1,7 @@
 using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading.Tasks;
-using DataAcquisition.Application.Clients;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Models;
 using HslCommunication.Core.Device;
 using HslCommunication.Profinet.Melsec;
@@ -11,7 +11,7 @@ namespace DataAcquisition.Infrastructure.Clients;
 /// <summary>
 /// 基于 HslCommunication 的 PLC 通讯客户端
 /// </summary>
-public class PlcClient : IPlcClient
+public class PlcClient : IPlcClientService
 {
     private readonly DeviceTcpNet _device;
 

--- a/DataAcquisition.Infrastructure/Clients/PlcClientFactory.cs
+++ b/DataAcquisition.Infrastructure/Clients/PlcClientFactory.cs
@@ -1,11 +1,11 @@
-using DataAcquisition.Application.Clients;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Models;
 
 namespace DataAcquisition.Infrastructure.Clients;
 
 public class PlcClientFactory : IPlcClientFactory
 {
-    public IPlcClient Create(DeviceConfig config)
+    public IPlcClientService Create(DeviceConfig config)
     {
         return new PlcClient(config);
     }

--- a/DataAcquisition.Infrastructure/DataProcessing/DataProcessingService.cs
+++ b/DataAcquisition.Infrastructure/DataProcessing/DataProcessingService.cs
@@ -1,6 +1,5 @@
 using DataAcquisition.Domain.Models;
-using DataAcquisition.Application.DataProcessing;
-using DataAcquisition.Application.OperationalEvents;
+using DataAcquisition.Application.Abstractions;
 
 namespace DataAcquisition.Infrastructure.DataProcessing;
 
@@ -9,9 +8,9 @@ namespace DataAcquisition.Infrastructure.DataProcessing;
 /// </summary>
 public class DataProcessingService : IDataProcessingService
 {
-    private readonly IOperationalEvents _events;
+    private readonly IOperationalEventsService _events;
 
-    public DataProcessingService(IOperationalEvents events)
+    public DataProcessingService(IOperationalEventsService events)
     {
         _events = events;
     }

--- a/DataAcquisition.Infrastructure/DataStorages/MySqlDataStorage.cs
+++ b/DataAcquisition.Infrastructure/DataStorages/MySqlDataStorage.cs
@@ -2,21 +2,19 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Dapper;
-using DataAcquisition.Application.DataStorages;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Models;
-using DataAcquisition.Application.OperationalEvents;
-using MySqlConnector;
 using Newtonsoft.Json;
 
 namespace DataAcquisition.Infrastructure.DataStorages;
 
-public class MySqlDataStorage : IDataStorage
+public class MySqlDataStorage : IDataStorageService
 {
     private static readonly Regex ParamCleanRegex = new(@"[^\w]+", RegexOptions.Compiled);
     private static readonly ConcurrentDictionary<string, (string Sql, Dictionary<string, string> Mapping)> SqlCache = new();
     private readonly string _connectionString;
-    private readonly IOperationalEvents _events;
-    public MySqlDataStorage(IConfiguration configuration, IOperationalEvents events)
+    private readonly IOperationalEventsService _events;
+    public MySqlDataStorage(IConfiguration configuration, IOperationalEventsService events)
     {
         _connectionString = configuration.GetConnectionString("MySQL") ?? throw new ArgumentNullException("MySql connection string is not configured.");
         _events = events;

--- a/DataAcquisition.Infrastructure/DeviceConfigs/DeviceConfigService.cs
+++ b/DataAcquisition.Infrastructure/DeviceConfigs/DeviceConfigService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using DataAcquisition.Application.DeviceConfigs;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Models;
 
 namespace DataAcquisition.Infrastructure.DeviceConfigs;

--- a/DataAcquisition.Infrastructure/OperationalEvents/OperationalEvents.cs
+++ b/DataAcquisition.Infrastructure/OperationalEvents/OperationalEvents.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using DataAcquisition.Application.OperationalEvents;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.OperationalEvents;
 using DataAcquisition.Gateway.Hubs;
 using Microsoft.AspNetCore.SignalR;
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace DataAcquisition.Infrastructure.OperationalEvents;
 
-public sealed class OperationalEvents : IOperationalEvents
+public sealed class OperationalEvents : IOperationalEventsService
 {
     private readonly ILogger<OperationalEvents> _log;
     private readonly IHubContext<DataHub> _hub;

--- a/DataAcquisition.Infrastructure/Queues/LocalQueue.cs
+++ b/DataAcquisition.Infrastructure/Queues/LocalQueue.cs
@@ -1,10 +1,7 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Channels;
-using DataAcquisition.Application.DataProcessing;
-using DataAcquisition.Application.DataStorages;
-using DataAcquisition.Application.OperationalEvents;
-using DataAcquisition.Application.Queues;
+using DataAcquisition.Application.Abstractions;
 using DataAcquisition.Domain.Models;
 
 namespace DataAcquisition.Infrastructure.Queues;
@@ -12,15 +9,15 @@ namespace DataAcquisition.Infrastructure.Queues;
 /// <summary>
 /// 消息队列实现
 /// </summary>
-public class LocalQueue : IQueue
+public class LocalQueue : IQueueService
 {
     private readonly Channel<DataMessage> _channel = Channel.CreateUnbounded<DataMessage>();
     private readonly ConcurrentDictionary<string, List<DataMessage>> _dataBatchMap = new();
-    private readonly IDataStorage _dataStorage;
+    private readonly IDataStorageService _dataStorage;
     private readonly IDataProcessingService _dataProcessingService;
-    private readonly IOperationalEvents _events;
+    private readonly IOperationalEventsService _events;
 
-    public LocalQueue(IDataStorage dataStorage, IDataProcessingService dataProcessingService, IOperationalEvents events)
+    public LocalQueue(IDataStorageService dataStorage, IDataProcessingService dataProcessingService, IOperationalEventsService events)
     {
         _dataStorage = dataStorage;
         _dataProcessingService = dataProcessingService;

--- a/README.en.md
+++ b/README.en.md
@@ -29,10 +29,10 @@ The PLC Data Acquisition System collects real-time operational data from program
 - **DataAcquisition.Gateway**: a reference gateway built with HslCommunication, serving as an example implementation.
 
 ### 🧰 How to customize implementation
-1. Implement `IPlcClient` and `IPlcClientFactory` to support other PLC protocols or communication methods.
-2. Implement `IDataStorage` to use a different database or persistence layer.
-3. Implement `IQueue` to integrate custom message queues.
-4. Implement `IOperationalEvents` to record errors, logs, or other operational events.
+1. Implement `IPlcClientService` and `IPlcClientFactory` to support other PLC protocols or communication methods.
+2. Implement `IDataStorageService` to use a different database or persistence layer.
+3. Implement `IQueueService` to integrate custom message queues.
+4. Implement `IOperationalEventsService` to record errors, logs, or other operational events.
 5. Implement `IDataProcessingService` to preprocess data before storage.
 6. Register these implementations in `Program.cs`, replacing the default dependencies.
 7. Build and run the project, adjusting configuration files as needed.
@@ -223,14 +223,14 @@ The service listens on http://localhost:8000 by default.
 
 ## 💻 Development
 ### 🔧 System configuration
-Register the `IDataAcquisition` instance in `Program.cs` to manage acquisition tasks.
+Register the `IDataAcquisitionService` instance in `Program.cs` to manage acquisition tasks.
 
 ```csharp
-builder.Services.AddSingleton<IOperationalEvents, OperationalEvents>();
+builder.Services.AddSingleton<IOperationalEventsService, OperationalEvents>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
 builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
 builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
-builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataAcquisitionService, DataAcquisitionService>();
 builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据�
 - **DataAcquisition.Gateway**：基于 HslCommunication 的参考实现，可作为自定义实现的示例。
 
 ### 🧰 如何自定义实现
-1. 实现 `IPlcClient` 与 `IPlcClientFactory`，以接入新的 PLC 协议或通讯方式。
-2. 实现 `IDataStorage` 以支持不同的数据库或持久化方案。
-3. 实现 `IQueue` 以扩展消息队列。
-4. 实现 `IOperationalEvents` 以记录错误、日志等运行事件。
+1. 实现 `IPlcClientService` 与 `IPlcClientFactory`，以接入新的 PLC 协议或通讯方式。
+2. 实现 `IDataStorageService` 以支持不同的数据库或持久化方案。
+3. 实现 `IQueueService` 以扩展消息队列。
+4. 实现 `IOperationalEventsService` 以记录错误、日志等运行事件。
 5. 实现 `IDataProcessingService` 以进行数据预处理。
 6. 在 `Program.cs` 中注册自定义实现，替换默认依赖。
 7. 构建并运行项目，按需调整配置文件。
@@ -221,14 +221,14 @@ dotnet run --project DataAcquisition.Gateway
 
 ## 💻 开发
 ### 🔧 系统配置
-在 `Program.cs` 中注册 `IDataAcquisition` 实例以管理采集任务。
+在 `Program.cs` 中注册 `IDataAcquisitionService` 实例以管理采集任务。
 
 ```csharp
-builder.Services.AddSingleton<IOperationalEvents, OperationalEvents>();
+builder.Services.AddSingleton<IOperationalEventsService, OperationalEvents>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
 builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
 builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
-builder.Services.AddSingleton<IDataAcquisition, DataAcquisition>();
+builder.Services.AddSingleton<IDataAcquisitionService, DataAcquisitionService>();
 builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
 


### PR DESCRIPTION
## Summary
- move application interfaces into new Abstractions folder
- rename IQueue and others to *Service for consistent naming
- update infrastructure, gateway, and docs to use new abstractions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c10fe30570832e958ccd58fe81a0cd