### PR TITLE
Refactor operational events using channel-based bus

### DIFF
--- a/DataAcquisition.Application/Abstractions/IOpsEventBus.cs
+++ b/DataAcquisition.Application/Abstractions/IOpsEventBus.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DataAcquisition.Domain.OperationalEvents;
+
+namespace DataAcquisition.Application.Abstractions;
+
+/// <summary>
+/// 运行事件消息总线接口。
+/// </summary>
+public interface IOpsEventBus
+{
+    /// <summary>
+    /// 发布运行事件。
+    /// </summary>
+    /// <param name="evt">运行事件</param>
+    /// <param name="ct">取消标记</param>
+    ValueTask PublishAsync(OpsEvent evt, CancellationToken ct = default);
+}

--- a/DataAcquisition.Gateway/OperationalEvents/OpsEventBroadcastWorker.cs
+++ b/DataAcquisition.Gateway/OperationalEvents/OpsEventBroadcastWorker.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DataAcquisition.Gateway.Hubs;
+using DataAcquisition.Infrastructure.OperationalEvents;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+
+namespace DataAcquisition.Gateway.OperationalEvents;
+
+/// <summary>
+/// 从事件通道读取并通过 SignalR 广播运行事件。
+/// </summary>
+public sealed class OpsEventBroadcastWorker : BackgroundService
+{
+    private readonly OpsEventChannel _channel;
+    private readonly IHubContext<DataHub> _hub;
+
+    public OpsEventBroadcastWorker(OpsEventChannel channel, IHubContext<DataHub> hub)
+    {
+        _channel = channel;
+        _hub = hub;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var evt in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            await _hub.Clients.All.SendAsync("ReceiveOpsEvent", evt, stoppingToken);
+        }
+    }
+}

--- a/DataAcquisition.Gateway/Program.cs
+++ b/DataAcquisition.Gateway/Program.cs
@@ -10,6 +10,7 @@ using DataAcquisition.Infrastructure.Queues;
 using DataAcquisition.Infrastructure.DataAcquisitions;
 using DataAcquisition.Application;
 using DataAcquisition.Gateway.OperationalEvents;
+using DataAcquisition.Infrastructure.OperationalEvents;
 using DataAcquisition.Infrastructure.DeviceConfigs;
 using Serilog;
 using Serilog.Events;
@@ -19,6 +20,8 @@ builder.WebHost.UseUrls("http://localhost:8000");
 builder.Services.AddMemoryCache();
 builder.Services.AddSignalR();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
+builder.Services.AddSingleton<OpsEventChannel>();
+builder.Services.AddSingleton<IOpsEventBus>(sp => sp.GetRequiredService<OpsEventChannel>());
 builder.Services.AddSingleton<IOperationalEventsService, OperationalEventsService>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
 builder.Services.AddSingleton<IQueueService, LocalQueueService>();
@@ -31,6 +34,7 @@ builder.Services.AddSingleton<IDataAcquisitionService, DataAcquisitionService>()
 
 builder.Services.AddHostedService<DataAcquisitionHostedService>();
 builder.Services.AddHostedService<QueueHostedService>();
+builder.Services.AddHostedService<OpsEventBroadcastWorker>();
 builder.Services.AddControllersWithViews();
 
 builder.Services.AddSignalR().AddJsonProtocol(o =>

--- a/DataAcquisition.Infrastructure/DataAcquisition.Infrastructure.csproj
+++ b/DataAcquisition.Infrastructure/DataAcquisition.Infrastructure.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="HslCommunication" Version="12.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="NCalcAsync" Version="5.4.0" />

--- a/DataAcquisition.Infrastructure/OperationalEvents/OpsEventChannel.cs
+++ b/DataAcquisition.Infrastructure/OperationalEvents/OpsEventChannel.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using DataAcquisition.Application.Abstractions;
+using DataAcquisition.Domain.OperationalEvents;
+
+namespace DataAcquisition.Infrastructure.OperationalEvents;
+
+/// <summary>
+/// 使用内存通道实现的运行事件总线。
+/// </summary>
+public sealed class OpsEventChannel : IOpsEventBus
+{
+    private readonly Channel<OpsEvent> _channel = Channel.CreateUnbounded<OpsEvent>();
+
+    public ValueTask PublishAsync(OpsEvent evt, CancellationToken ct = default)
+        => _channel.Writer.WriteAsync(evt, ct);
+
+    /// <summary>
+    /// 用于消费事件的读取器。
+    /// </summary>
+    public ChannelReader<OpsEvent> Reader => _channel.Reader;
+}

--- a/README.en.md
+++ b/README.en.md
@@ -226,7 +226,9 @@ The service listens on http://localhost:8000 by default.
 Register the `IDataAcquisitionService` instance in `Program.cs` to manage acquisition tasks.
 
 ```csharp
-builder.Services.AddSingleton<IOperationalEventsService, OperationalEvents>();
+builder.Services.AddSingleton<OpsEventChannel>();
+builder.Services.AddSingleton<IOpsEventBus>(sp => sp.GetRequiredService<OpsEventChannel>());
+builder.Services.AddSingleton<IOperationalEventsService, OperationalEventsService>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
 builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
 builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
@@ -235,6 +237,7 @@ builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
 
 builder.Services.AddHostedService<DataAcquisitionHostedService>();
+builder.Services.AddHostedService<OpsEventBroadcastWorker>();
 ```
 
 ### 🗂️ Repository structure

--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ dotnet run --project DataAcquisition.Gateway
 在 `Program.cs` 中注册 `IDataAcquisitionService` 实例以管理采集任务。
 
 ```csharp
-builder.Services.AddSingleton<IOperationalEventsService, OperationalEvents>();
+builder.Services.AddSingleton<OpsEventChannel>();
+builder.Services.AddSingleton<IOpsEventBus>(sp => sp.GetRequiredService<OpsEventChannel>());
+builder.Services.AddSingleton<IOperationalEventsService, OperationalEventsService>();
 builder.Services.AddSingleton<IPlcClientFactory, PlcClientFactory>();
 builder.Services.AddSingleton<IDataStorageFactory, DataStorageFactory>();
 builder.Services.AddSingleton<IQueueFactory, QueueFactory>();
@@ -233,6 +235,7 @@ builder.Services.AddSingleton<IDataProcessingService, DataProcessingService>();
 builder.Services.AddSingleton<IDeviceConfigService, DeviceConfigService>();
 
 builder.Services.AddHostedService<DataAcquisitionHostedService>();
+builder.Services.AddHostedService<OpsEventBroadcastWorker>();
 ```
 
 ### 🗂️ 仓库结构


### PR DESCRIPTION
## Summary
- add IOpsEventBus abstraction and channel-based implementation
- move OperationalEventsService to infrastructure and publish events via bus
- add background worker to broadcast events to SignalR hub
- wire up bus and worker in Program and update docs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c11e3de840832e89c21119263862d4