### PR TITLE
docs: categorize nuget dependencies

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -37,6 +37,23 @@ The PLC Data Acquisition System collects real-time operational data from program
 6. Register these implementations in `Program.cs`, replacing the default dependencies.
 7. Build and run the project, adjusting configuration files as needed.
 
+## 📦 NuGet Packages
+### 🧱 Framework dependencies
+The core framework relies on the following NuGet packages:
+- [Microsoft.Extensions.Caching.Memory](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory) 9.0.2: in-memory caching.
+- [NCalcAsync](https://www.nuget.org/packages/NCalcAsync) 5.4.0: evaluates expressions before data persistence.
+- [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) 13.0.3: JSON serialization/deserialization.
+
+### 🧪 Example dependencies
+The reference gateway and sample implementations use:
+- [Dapper](https://www.nuget.org/packages/Dapper) 2.1.66: lightweight ORM for data access.
+- [HslCommunication](https://www.nuget.org/packages/HslCommunication) 12.2.0: PLC communication library.
+- [Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR) 1.2.0: real-time web communication.
+- [MySqlConnector](https://www.nuget.org/packages/MySqlConnector) 2.4.0: high-performance MySQL client.
+- [Serilog.AspNetCore](https://www.nuget.org/packages/Serilog.AspNetCore) 9.0.0: Serilog logging integration.
+- [Serilog.Sinks.Console](https://www.nuget.org/packages/Serilog.Sinks.Console) 6.0.0: console log sink.
+- [Serilog.Sinks.File](https://www.nuget.org/packages/Serilog.Sinks.File) 7.0.0: file log sink.
+
 ## 🌐 Environment Requirements
 - .NET 8.0 SDK
 - Optional: RabbitMQ or Kafka (for message queues)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ PLC 数据采集系统用于从可编程逻辑控制器实时收集运行数据�
 6. 在 `Program.cs` 中注册自定义实现，替换默认依赖。
 7. 构建并运行项目，按需调整配置文件。
 
+## 📦 NuGet 包
+### 🧱 基础框架依赖
+核心框架使用以下 NuGet 包：
+- [Microsoft.Extensions.Caching.Memory](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory) 9.0.2：提供内存缓存功能。
+- [NCalcAsync](https://www.nuget.org/packages/NCalcAsync) 5.4.0：在数据写入前执行表达式计算。
+- [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) 13.0.3：用于 JSON 序列化与反序列化。
+
+### 🧪 示例依赖
+参考实现（如 `DataAcquisition.Gateway`）使用以下 NuGet 包：
+- [Dapper](https://www.nuget.org/packages/Dapper) 2.1.66：轻量级 ORM，用于数据访问。
+- [HslCommunication](https://www.nuget.org/packages/HslCommunication) 12.2.0：支持多种 PLC 通讯协议。
+- [Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR) 1.2.0：实现实时 Web 通讯。
+- [MySqlConnector](https://www.nuget.org/packages/MySqlConnector) 2.4.0：高性能 MySQL 客户端驱动。
+- [Serilog.AspNetCore](https://www.nuget.org/packages/Serilog.AspNetCore) 9.0.0：集成 Serilog 日志框架。
+- [Serilog.Sinks.Console](https://www.nuget.org/packages/Serilog.Sinks.Console) 6.0.0：将日志输出到控制台。
+- [Serilog.Sinks.File](https://www.nuget.org/packages/Serilog.Sinks.File) 7.0.0：将日志写入文件。
+
 ## 🌐 环境要求
 - .NET 8.0 SDK
 - 可选：RabbitMQ 或 Kafka（用于消息队列）


### PR DESCRIPTION
## Summary
- move Dapper and MySqlConnector entries to example dependency lists in Chinese and English README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1347762a8832ea8fe59cb5001b102