### PR TITLE
Edge api request errors

### DIFF
--- a/src/DataAcquisition.Edge.Agent/Services/EdgeReportingOptions.cs
+++ b/src/DataAcquisition.Edge.Agent/Services/EdgeReportingOptions.cs
@@ -16,6 +16,13 @@ public sealed class EdgeReportingOptions
     public string CentralApiBaseUrl { get; init; } = "http://localhost:8000";
 
     /// <summary>
+    /// 可选：Edge.Agent 对中心可达的基础地址（例如 http://10.0.0.12:8001）。
+    /// 用于中心侧代理查询 edge 的 metrics / logs。
+    /// 为空时会尝试从 Urls/ASPNETCORE_URLS 推导（如果是 0.0.0.0/+/* 之类通配监听地址则无法推导）。
+    /// </summary>
+    public string? AgentBaseUrl { get; init; }
+
+    /// <summary>
     /// 可选：固定 EdgeId。为空时会从 IdentityFilePath 读取/生成并持久化。
     /// </summary>
     public string? EdgeId { get; init; }

--- a/src/DataAcquisition.Edge.Agent/appsettings.json
+++ b/src/DataAcquisition.Edge.Agent/appsettings.json
@@ -20,6 +20,7 @@
   "Edge": {
     "EnableCentralReporting": true,
     "CentralApiBaseUrl": "http://localhost:8000",
+    "AgentBaseUrl": "http://localhost:8001",
     "EdgeId": "EDGE-001",
     "HeartbeatIntervalSeconds": 10
   },


### PR DESCRIPTION
Enable Edge.Agent to report its base URL to the Central API and refine Central API's error handling for missing base URLs.

The `api/edges/{edgeId}/metrics/json` and `.../logs` endpoints on the Central API were returning 400 Bad Request because the `Edge.Agent` was not sending its `AgentBaseUrl` during registration or heartbeat. This prevented the Central API from knowing where to proxy these requests. This PR adds `AgentBaseUrl` reporting to the agent and changes the Central API to return more specific HTTP status codes (404 for not found, 409 for missing `AgentBaseUrl`) with helpful hints.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8ab4302-e1d5-42a7-8671-9cd52c5a9a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8ab4302-e1d5-42a7-8671-9cd52c5a9a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

